### PR TITLE
Adding government types that we have in chicago

### DIFF
--- a/proposals/0003.rst
+++ b/proposals/0003.rst
@@ -62,6 +62,10 @@ classification
                        legislative-executive government.  An example would be the cabinet in
                        `Westminster systems <http://en.wikipedia.org/wiki/Westminster_system>`_.
     * school_system  - A school system that is independent from a city/county government.
+    * park_district  - A park district that is independent from a city/county government.
+    * sewerage_district - A sewerage district that is independent from a city/county government.
+    * forest_preserve_district - A forest preserve district that is independent from city/county government
+    * transity_authority - An independent transit autority
 
 division, division_id
     A link to an Open Civic Data division (or the object itself embedded within the Jurisdiction).


### PR DESCRIPTION
In Cook county, the sewerage district, the park district, forest preserve district, and transit authority all have separate charters and taxing authorities. 

They are distinct from both the state, county, and city governments, but the degree of 'independence' varies:

The sewerage district has an elected board. The transit authority and park district have boards that are appointed by both state and local level executives. The forest preserve district's board of commissioners are just the Cook County board of commissioners. 

All of these entities also have weird, often highly non-contiguous associated 'districts.' For the park district and forest preserve it's land owned by the park district and forest preserve. For the sewerage district is Chicago and other municipalities that have agreed to be serviced by the district. For the transit authority it's property owned by the authority.

Do we want all these types of governmental units in opencivicdata?
