### PR TITLE
Rename session to legislative_session

### DIFF
--- a/proposals/0006.rst
+++ b/proposals/0006.rst
@@ -24,7 +24,7 @@ Implementation
 id
     A unique ID in the format ``ocd-bill/{uuid}``.
 
-session
+legislative_session
     A reference to a ``legislative_session`` from the relevant ``Jurisdiction`` (see :ref:`OCDEP3` for details). This must contain the ``name`` attribute at minimum, but ``may`` contain any valid object that is found in the ``Jurisdiction.legislative_session`` object.
 
 identifier

--- a/proposals/0007.rst
+++ b/proposals/0007.rst
@@ -75,7 +75,7 @@ result
 organization, organization_id
     The ``Organization`` in which the ``VoteEvent`` took place.
 
-session, session_id
+legislative_session, legislative_session_id
     Reference to the ``Jurisdiction.legislative_session`` the ``VoteEvent`` takes place in.
 
 bill, bill_id


### PR DESCRIPTION
I think `legislative_session` instead of `session` can avoid confusion, because "session" can refer to a meeting/sitting, as in "plenary session". I've had at least one implementer confuse the two, so I'm thinking I'd rather use `legislative_session` in Popolo.
