### PR TITLE
Change to entity_type to sync with Bills

### DIFF
--- a/proposals/0004.rst
+++ b/proposals/0004.rst
@@ -161,7 +161,7 @@ subjects
 Related Entities
 ++++++++++++++++
 
-type
+entity_type
     Type of the related entity, such as ``bill``, ``person``, or ``organization``.
 
 id
@@ -518,7 +518,7 @@ Schema::
                         "related_entities": {
                             "items": {
                                 "properties": {
-                                    "type": {
+                                    "entity_type": {
                                         "type": "string",
                                     },
 


### PR DESCRIPTION
This also lets us use the related entity base correctly; bug in hiding.

https://github.com/opencivicdata/pupa/commit/5970d0fada7fe496fb9a9d87f75d27cc6e80cfae
