### PR TITLE
Filling out Elections proposal

### DIFF
--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -202,7 +202,7 @@ Mapping to VIP
 
 * OCD fields not implemented in VIP:
 
-    - ``administrative_organization_id`` is optional.
+    - ``administrative_organization_id`` is an optional reference to an OCD ``Organization`` that can be equivalent to the ``<Department>`` tag in VIP's `<ElectionAdministration> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election_administration.html>`_   element.
     - ``classification`` (inherited from ``Event``) should be "election".
     - ``description`` (inherited from ``Event``) is optional.
     - ``location`` (inherited from ``Event``) is optional.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -51,10 +51,10 @@ Candidacy
     * The person competed to hold the same public office in more than one election. This includes:
 
         - A person who is elected to a public office, serves a full term and runs for re-election as an incumbent candidate.
-        - A person who wins a contest to become a nominee for a public office (known as a "primary election" in U.S. politics) who goes on to face who advances the final contest of candidates (e.g., the "general election" in U.S. politics).
+        - A person who wins a contest to become a nominee for a public office (known as a "primary election" in U.S. politics) who advances to the final contest of candidates (aka, the "general election").
 
 Candidate
-    A person competing to be elected to hold particular public office.
+    A person competing to be elected to hold a particular public office.
 
 Contest
     A specific decision with a set of predetermined options (aka, "selections") put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
@@ -75,18 +75,18 @@ Public Office
     A position within a governmental body which is filled through an election contest.
 
 Runoff Contest
-    A contest conducted to decide a previous contest in which no single selection received the number of votes required to decide the election.
+    A contest conducted to decide a previous contest in which no single selection received the required number of votes to decide the contest.
 
 Selection
     A predetermined option that voters could select on a ballot in an election contest.
 
 Term of Office
-    The period of time a person elected to a public office is expected to hold the public office before being re-elected or replaced.
+    The period of time a person elected to a public office is expected retain the position before being re-elected or replaced.
 
-    For a variety of reasons, a public office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
+    For a variety of reasons, an office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
 
 Ticket
-    Two or more allied candidates competing together in the same contest in which multiple public offices are decided. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
+    Two or more allied candidates competing together in the same contest fill two or more public offices. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
 
 Vote
     A specific selection selected by a voter on a ballot in an election contest.
@@ -95,7 +95,7 @@ Voter
     A person who is eligible to vote in an election.
 
 Write-in
-    A vote in a contest wherein the voter explicitly names a preferred selection, forgoing the selections listed on the ballot.
+    A vote in a contest wherein the voter explicitly names a preferred selection for an election contest, rather than choosing from among the predetermined selections listed on the ballot.
 
 
 Rationale
@@ -121,14 +121,16 @@ Differences from VIP
 
 Each of the data types described in this proposal corresponds to an element described in the VIP's current `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_. While interoperability with VIP data is a goal of this proposal, there is not a one-to-one mapping between the tags within a VIP element and the properties of its corresponding data type in this OCDEP.
 
-Important differences between the proposed OCD data type and its corresponding VIP element are noted, if any, in each data type's "Mapping to VIP" subsection in Implementation_.
+Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 
 One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``pro_statement`` and ``con_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
 
 Questions
 =========
 
-* Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But most users will to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
+* Should either ``Election`` subclass ``Event``?
+* Should ``Contest`` subclass ``VoteEvent``?
+* Should ``Party`` be implemented as an ``Organization`` (or subclass)?
 * Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
 * Should competing to hold a public office in both the primary and the general election count as one candidacy or two?
 
@@ -150,10 +152,10 @@ identifiers
     Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
 
 name
-    Common name for the election, which will typically describe approximately when the election occurred and the scope of the contests to be decided, e.g., "2014 Primaries", "2015 Boone County Elections" or "2016 General Elections" (string).
+    Common name for the election. Typically describes roughly when the election occurred and the scope of the contests to be decided, e.g., "2014 Primaries", "2015 Boone County Elections" or "2016 General Elections" (string).
 
 date
-    Date on which the election is set to be decided (aka, Election Day). Typically this corresponds to the last day when voters can cast a ballot and the first day when the election's results a publicly reported (date).
+    Date on which the election is set to be decided (aka, Election Day). This tends to be the last day when voters can cast their ballots and the first day when the election's results a publicly reported (date).
 
     This date should be considered to be in the timezone local to the election's division.
 
@@ -227,7 +229,7 @@ Mapping to VIP
 * Important differences between corresponding fields:
 
     - ``<Name>`` is not required on VIP, but ``name`` is required on OCD's ``Event``.
-    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, roughly corresponds to ``division_id`` which should reference the same state (if ``<IsStatewide>`` is true on the VIP election) or any of its subdivisions.
+    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, maps to ``division_id``. If ``<IsStatewide>`` is true on the VIP election, then ``division_id`` will reference the same state. Otherwise, it should reference one of the state's subdivisions.
 
 * OCD fields not implemented in VIP:
 
@@ -344,7 +346,20 @@ BallotMeasureContest
 
 A subclass of ``Contest`` for representing a ballot measure before the voters, including summary statements on each side. Inherits all of the required and optional properties of ``Contest``.
 
-con_statement
+
+summary
+    **optional**
+    Short summary of the ballot measure that is on the ballot, below the title, but above the text.
+
+text
+    **optional**
+    The full text of the ballot measure as it appears on the ballot (string).
+
+support_statement
+    **optional**
+    A statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
+
+oppose_statement
     **optional**
     A statement in opposition to the ballot measure. It does not necessarily appear on the ballot (string).
 
@@ -355,18 +370,6 @@ effect_of_abstain
 requirement
     **optional**
     The threshold of votes the ballot measure needs in order to pass (string). The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
-
-pro_statement
-    **optional**
-    A statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
-
-summary
-    **optional**
-    Short summary of the ballot measure that is on the ballot, below the title, but above the text.
-
-text
-    **optional**
-    The full text of the ballot measure as it appears on the ballot (string).
 
 classification
     **optional**
@@ -399,11 +402,11 @@ Sample BallotMeasureContest
             }
         ],
         "extras": {},
-        "con_statement": "",
+        "support_statement": "",
+        "oppose_statement": "",
         "effect_of_abstain": "",
         "text": "",
-        "passage_threshold": "50% plus one vote",
-        "pro_statement": "",
+        "requirement": "50% plus one vote",
         "summary": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
         "ballot_measure_type": "initiative statute"
     }
@@ -412,9 +415,7 @@ Sample BallotMeasureContest
 Mapping to VIP
 ++++++++++++++
 
-``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element.
-
-``<InfoUri>``, which is optional in VIP, is not implemented in this OCDEP.
+``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element. It includes an optional ``<InfoUri>``, which is not implemented in this OCDEP.
 
 
 CandidateContest
@@ -434,8 +435,15 @@ number_elected
     Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
 
 post_ids
-    **repeating**
-    Lists each identifier of an OCD ``Post`` representing a public office for which the candidates are competing in the contest. If multiple, the primary post should be listed first, e.g., the id for the President post should be listed before the id for Vice-President.
+    **repeated**
+    Lists each identifier of an OCD ``Post`` representing a public office for which the candidates are competing in the contest. Has the following properties:
+
+        post_id
+            Reference to an OCD ``Post``.
+
+        sort_order
+            **optional**
+            Useful sorting posts in contests where two or more public offices are at stake.
 
 party_id
     **optional**
@@ -468,6 +476,12 @@ Sample CandidateContest
         ],
         "extras": {},
         "filing_deadline": 2016-06-07,
+        "posts": [
+            {
+                "id": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
+                "sort_order": 0
+            }
+        ],
         "is_unexpired_term": false,
         "number_elected": 1,
         "party_id": null,
@@ -482,7 +496,7 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, is replaced by ``post_ids``, which is a repeating field that requires at least one reference to an OCD ``Post``.
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, is replaced by ``post_ids``, which is a repeated field that requires at least one reference to an OCD ``Post``. In VIP, the primary office should be listed first. In OCD, the primary post should have ``is_primary`` set to true.
 
 * OCD fields not implemented in VIP:
 
@@ -601,10 +615,6 @@ is_incumbent
     **optional**
     Indicates whether the candidate is the incumbent for the office associated with the contest (boolean).
 
-is_top_ticket
-    **optional**
-    Indicates that the candidate is the top of a ticket that includes multiple candidates (boolean). For example, the candidate running for President is consider the top of the President/Vice President ticket. In many states, this is also true of the Governor/Lieutenant Governor.
-
 party_id
     **optional**
     Reference to and OCD ``Party`` with which the candidate is affiliated.
@@ -645,7 +655,6 @@ Sample Candidacy
         "filed_date": 2016-03-10,
         "ballot_selection_id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f",
         "is_incumbent": false,
-        "is_top_ticket": false,
         "party_id": 'ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1',
         "created_at": "2017-02-08T04:17:30.818Z",
         "updated_at": "2017-02-08T04:17:30.818Z",

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -55,7 +55,7 @@ Contest
     * Selecting a preferred political party to hold power.
 
 Election
-    A collection of political contests held within a political geography that are decided in parallel through a process of compiling official ballots cast by voters and adding up the total votes for each selection in each contest.
+    A collection of political contests held within a political geography that are decided in parallel through a process of compiling official ballots cast by voters and adding up the total votes for each option in each contest.
 
 Election Day
     The final or only date when eligible voters may cast their ballots in an election. Typically this is also the same date when results of the election's contests are first publicly reported.
@@ -83,7 +83,7 @@ Ticket
     Note that candidates on the same ticket are not necessarily affiliated with the same political party.
 
 Write-in
-    A vote in a contest wherein the voter explicitly names a preferred selection for an election contest, rather than choosing from among the predetermined selections listed on the ballot.
+    A vote in a contest wherein the voter explicitly names a preferred option for an election contest, rather than choosing from among the predetermined options listed on the ballot.
 
 
 Rationale
@@ -107,10 +107,11 @@ VIP 5, the specification's current version, incorporates elements from the `Elec
 Differences from VIP
 --------------------
 
-The two major differences are:
+The three major differences are:
 
 1. VIP models a single election, whereas this proposal intends to model previous and pending elections. As such, certain OCD data types are independent of and linked to multiple elections and/or election contests, unlike their corresponding VIP elements. 
-2. VIP models more precise details of elections, including where voters can vote and variations in the order of contests and options as they appear on ballots. These details are beyond the scope of this proposal, which is more focused on representing the distinct election contests and their potential outcomes.
+2. VIP models precise details about ballots, including the exact wording and order of the options (VIP refers to these as "selections") presented to voters in a given jurisdiction. These details are beyond the scope of this proposal.
+3. VIP models details about polling locations, including their addresses and hours. These details are also beyond the scope of this proposal.
 
 Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -125,16 +125,6 @@ Important differences between the proposed OCD data type and its corresponding V
 
 One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
 
-Questions
-=========
-
-* Should ``Election`` subclass ``Event``?
-* Should ``Contest`` subclass ``VoteEvent``?
-* Should ``Party`` be implemented as an ``Organization`` (or subclass)?
-* Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
-* Should competing to hold a public office in both the primary and the general election count as one candidacy or two?
-
-
 Implementation
 ==============
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -31,7 +31,7 @@ Definitions
 ===========
 
 Ballot Measure
-    A proposition or question with two or more predetermined options that voters may select as part of an election. These include:
+    A proposition or question with two or more predetermined options put before voters in an election. These include:
 
     * The enactment or repeal of a statute, constitutional amendment or other form of law.
     * Approval or rejection of a new tax or additional spending of public funds.
@@ -40,6 +40,7 @@ Ballot Measure
 Candidacy
     The condition of a person being a candidate. A single person may have multiple candidacies if:
 
+    * The person competed in multiple elections, even for the same office term. This includes a candidate in an initial or "primary" election who advances to be a candidate in the "general" election.
     * The person competed to hold multiple public offices, even in the same election.
     * The person was elected to serve a term in a public office and later sought re-election to the same public office.
 
@@ -49,7 +50,7 @@ Candidate
 Contest
     A specific decision with a set of predetermined options put before voters in an election. These contests include:
 
-    * Selecting candidates to serve terms in public offices.
+    * Selecting candidates to hold public offices.
     * Selecting options set forth in a ballot measure.
     * Selecting a preferred political party to hold power.
 
@@ -77,7 +78,7 @@ Runoff Contest
     A contest conducted to decide a previous contest in which no single option received the required number of votes to decide the contest.
 
 Ticket
-    Two or more allied candidates competing together in the same contest where terms in multiple related public offices are at stake. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
+    Two or more allied candidates competing together in the same contest where multiple related public offices are at stake. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
 
     Note that candidates on the same ticket are not necessarily affiliated with the same political party.
 
@@ -104,22 +105,22 @@ Our use cases require unique representations of both previous elections and cont
 VIP 5, the specification's current version, incorporates elements from the `Election Results Common Data Format Specification <https://www.nist.gov/itl/voting/nist-election-results-common-data-format-specification>`_ defined by the National Institute of Standard and Technology. As such, we have borrowed eagerly from NIST's current specification also.
 
 Differences from VIP
-++++++++++++++++++++
+--------------------
 
 The two major differences are:
 
 1. VIP models a single election, whereas this proposal intends to model previous and pending elections. As such, certain OCD data types are independent of and linked to multiple elections and/or election contests, unlike their corresponding VIP elements. 
-2. VIP models finer details about an election, including where voters can vote and the exact wording of their ballots. These details are beyond the scope of this proposal, which is more focused on representing the distinct election contests and their potential outcomes.
+2. VIP models more precise details of elections, including where voters can vote and variations in the order of contests and options as they appear on ballots. These details are beyond the scope of this proposal, which is more focused on representing the distinct election contests and their potential outcomes.
 
 Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 
-Additionally, VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
+Additionally, VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. These are treated as strings in this proposal.
 
 Implementation
 ==============
 
 Election
----------
+--------
 
 A collection of political contests set to be decided on the same date within a political geography (aka, ``Division``).
 
@@ -201,6 +202,7 @@ Mapping to VIP
 * OCD fields not implemented in VIP:
 
     - ``administrative_organization_id`` is optional.
+    - ``classification`` (inherited from ``Event``) should be "election".
     - ``description`` (inherited from ``Event``) is optional.
     - ``location`` (inherited from ``Event``) is optional.
     - ``all_day`` (inherited from ``Event``) is optional.
@@ -213,12 +215,12 @@ Mapping to VIP
 
 * VIP fields not implemented in this OCDEP:
 
-    - ``<ElectionType>``, which is an optional string that conflates the level of government to which a candidate might be elected (e.g., "federal", "state", "county", etc.) with the point when the election occurs in the overall cycle (e.g., "general", "primary", "runoff" and "special").
+    - ``<ElectionType>``, which is optional for describing either the level of government to which a candidate might be elected (e.g., "federal", "state", "county", etc.) or the point when the election occurs in the overall cycle (e.g., "general", "primary", "runoff" and "special").
     - ``<HoursOpenId>``, which is an optional reference to a VIP `<HoursOpen> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/hours_open.html>`_ element that represents when polling locations for the election are generally open.
-    - ``<RegistrationInfo>``, which is an optional string.
+    - ``<RegistrationInfo>``, which optional text.
     - ``<RegistrationDeadline>``, which is an optional date.
     - ``<HasElectionDayRegistration>``, which is an optional boolean.
-    - ``<AbsenteeBallotInfo>``, which is an optional string.
+    - ``<AbsenteeBallotInfo>``, which is optional text.
     - ``<AbsenteeRequestDeadline>``, which is an optional date.
     - ``<ResultsUri>``, which is optional.
 
@@ -305,8 +307,8 @@ Mapping to VIP
 
 * VIP fields not implemented in this OCDEP:
 
-    - ``<Abbreviation>``, which is an optional string.
-    - ``<BallotSelectionIds>`` is an optional single element that contains a set of references to each selection (i.e., any extension of VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_) on any ballot that includes the contest. This proposal instead implements properties on the subclasses of ``Contest`` for storing the distinct options for each contest across all versions of the ballot (e.g., the ``BallotMeasureContest.options`` and ``CandidateContest.candidacies`` properties).
+    - ``<Abbreviation>``, which is optional text.
+    - ``<BallotSelectionIds>`` is an optional single element that contains a set of references to each selection (i.e., any extension of VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_) on any ballot that includes the contest. This proposal instead represents the distinct options for each contest across all versions of the ballot.
     - ``<ElectorateSpecification>``, which optional text.
     - ``<HasRotation>``, which is an optional boolean.
     - ``<BallotSubTitle>``,  which is optional text.
@@ -391,7 +393,7 @@ Mapping to VIP
 
 * OCD fields not implemented in VIP:
 
-    - ``options`` should list the distinct selections across all ballots that include the ``<BallotMeasureContest>`` (i.e., the ``<Selection>`` tag in the `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+    - ``options`` should list the distinct selections across all ballots that include the ballot measure (i.e., the distinct ``<Selection>`` tags in the `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
 
 * VIP fields not implemented in this OCDEP:
 
@@ -413,20 +415,16 @@ number_elected
     **optional**
     Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
 
-office_terms
+posts
     **repeated**
-    List of references to each OCD ``OfficeTerm`` representing a term of public office for which the candidates in the contest are seeking election. Requires at least one. Has the following properties:
+    List of references to each OCD ``Post`` representing a public office for which the candidates in the contest are seeking election. Requires at least one. Has the following properties:
 
-    office_term_id
+    post_id
         Reference to an OCD ``OfficeTerm``.
 
     sort_order
         **optional**
         Useful for sorting for contests where two or more public offices are at stake, e.g., in a U.S. presidential contest, the President post would have a lower sort order than the Vice President post.
-
-candidacy_ids
-    **repeated**
-    List of references to each candidacy for one of the public office terms at stake in the contest. Requires at least one.
 
 party_id
     **optional**
@@ -458,16 +456,11 @@ Sample CandidateContest
             }
         ],
         "extras": {},
-        "office_terms": [
+        "posts": [
             {
-                "office_term_id": "ocd-officeterm/08d670db-72cb-495b-afdd-f7f91794ad8d",
+                "post": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
                 "sort_order": 0
             }
-        ],
-        "candidacy_ids": [
-            "ocd-candidacy/153344e1-e533-4a05-880c-a332038cb785",
-            "ocd-candidacy/e029a7a6-665a-4b7b-82f7-1ab554905518",
-            "ocd-candidacy/355e4858-847c-4cf5-88d6-c8d1de167e07"
         ],
         "is_unexpired_term": false,
         "number_elected": 1,
@@ -483,11 +476,10 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, should each map to an OCD ``OfficeTerm``. The order in which the OfficeIds are listed should be preserved in ``sort_order``.
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>``should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
 
 * OCD fields not implemented in VIP:
 
-    + ``candidacy_ids`` should list the distinct candidate selections across all ballots that include the ``<CandidateContest>`` (i.e., each OCD ``Candidacy`` equivalent to each VIP ``<Candidate>`` referenced in the ``<CandidateIds>`` tag in the `<CandidateSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
     + ``runoff_for_contest_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:
@@ -498,7 +490,7 @@ Mapping to VIP
 PartyContest
 ------------
 
-A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of or in addition to candidates for public office endorsed by that party (as in the case of `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_ ). Inherits all the required and optional properties of ``Contest``.
+A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of/in addition voting for to candidates endorsed by that party (as in the case of `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_ ). Inherits all the required and optional properties of ``Contest``.
 
 parties
     **repeated**
@@ -525,8 +517,8 @@ Sample PartyContest
     {
         "id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
         "identifiers": [],
-        "name": "",
-        "division_id": "ocd-division/country:us/state:ca/sldu:1",
+        "name": "Elections for the 20th Knesset",
+        "division_id": "ocd-division/country:il",
         "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:18:05.438Z",
         "updated_at": "2017-02-07T07:18:05.442Z",
@@ -618,7 +610,7 @@ Mapping to VIP
 Candidacy
 ---------
 
-A person competing to serve a term in a specific public office.
+A person competing in an election contest to hold a specific office for a term.
 
 id
     Open Civic Data-style id in the format ``ocd-candidacy/{{uuid}}``.
@@ -626,16 +618,15 @@ id
 person_id
     Reference to an OCD ``Person`` who is the candidate.
 
-office_term_id
-    Reference to the OCD ``OfficeTerm`` representing the term of public office for which the candidate is seeking election.
+post_id
+    Reference to the OCD ``Post`` representing the public office for which the candidate is seeking election.
+
+contest_id
+    Reference to an OCD ``CandidateContest`` representing the contest in which the candidate is competing.
 
 candidate_name
     **optional**
     For preserving the candidate's name as it was when the person sought election to hold the public office term, which may differ from the person's current name (string).
-
-committee_id
-    **optional**
-    Reference to the OCD ``Committee`` (see OCDEP: Campaign Finance Filings) that represents the candidate's campaign committee for the contest.
 
 filed_date
     **optional**
@@ -682,10 +673,11 @@ Sample Candidacy
 
     {
         "id": "ocd-candidacy/054f0a6e-9c06-4611-8c2c-3e143843c9d8",
-        "candidate_name": "ROWEN, ROBERT J.",
         "person_id": "ocd-person/edfafa56-686d-49ea-80e5-64bc795493f8",
-        "committee_id": null,
-        "filed_date": 2016-03-10,
+        "post": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
+        "contest_id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
+        "candidate_name": "ROWEN, ROBERT J.",
+        "filed_date": "2016-03-10",
         "is_incumbent": false,
         "party_id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1",
         "top_ticket_candidacy_id": null,
@@ -709,6 +701,7 @@ Mapping to VIP
 
 * OCD fields not implemented in VIP:
       
+    - ``contest_id`` is a required reference to an OCD ``CandidateContest`` which should be the equivalent of the VIP ``<CandidateContest>`` to which the equivalent VIP ``<Candidate>`` is linked.
     - ``committee_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:
@@ -716,92 +709,6 @@ Mapping to VIP
     - ``<ContactInformation>`` refers to an element that describes the contact and physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be stored on the associated ``Person`` or ``Committee`` object.
     - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_.
     - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_.
-
-
-OfficeTerm
-----------
-The interval in which an elected candidate is expected to hold a public office before being re-elected or replaced.
-
-id
-    Open Civic Data-style id in the format ``ocd-officeterm/{{uuid}}``.
-
-post_id
-    Reference to the OCD ``Post`` representing the public office held for the interval.
-
-start_date
-    Date the office holder's term is expected to start. Not necessarily the same as the date when the person began serving in the office (as in the case of a re-election).
-
-end_date
-    Date the office holder's term is expected to end. Not necessarily the same as the date when the office holder vacated the office.
-
-previous_term_unexpired
-    Indicates the previous public office holder vacated the post before serving a full term (boolean).
-
-filing_deadline
-    **optional**
-    Specifies the date and time by when persons must of official filed their candidacies for election or re-election (datetime).
-
-created_at
-    Specifies when this object was created in the system (datetime).
-
-updated_at
-    Specifies when this object was last updated in the system (datetime).
-
-sources
-    **optional**
-    **repeated**
-    List of sources used in assembling this object. Has the following properties:
-
-    url
-        URL of the resource.
-    note
-        **optional**
-        Description of what this source was used for.
-
-extras
-    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
-
-
-Sample OfficeTerm
-+++++++++++++++++
-
-
-.. code:: javascript
-
-    {
-        "id": "ocd-officeterm/08d670db-72cb-495b-afdd-f7f91794ad8d",
-        "post_id": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
-        "filing_deadline": "2016-09-01T01:01:00.000Z",
-        "start_date": "2017-01-04",
-        "end_date": "2021-01-04",
-        "pervious_term_unexpired": false,
-        "created_at": "2017-02-07T16:36:12.497Z",
-        "updated_at": "2017-02-07T16:36:12.497Z",
-        "sources": [],
-        "extras": {}
-    }
-
-
-Mapping to VIP
-++++++++++++++
-
-``Post`` and ``OfficeTerm`` correspond to VIP's `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ and `<Term> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html#term>`_ elements.
-
-* Important differences between corresponding fields:
-  
-    - ``<Name>`` on VIP's ``<Office>`` maps to ``label`` on OCD's ``Post``.
-    - ``<ElectoralDistrictId>`` on VIP's ``<Office>``, which is a required reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, should map to an equivalent OCD ``division_id``.
-    - ``<ContactInformation>`` on VIP's ``<Office>`` maps to the ``contact_details`` on OCD's ``Post``.
-    - ``<OfficeHolderPersonIds>`` on VIP's ``<Office>`` is an optional single tag that contains a set of references  to each office holder represented, as a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_. Each of these can map to an equivalent OCD ``Membership`` (i.e., a combination of a ``Person``/``Post``/``Organization``).
-    - A VIP ``<Office>`` can only have a single ``<Term>``, but an OCD ``Post`` can be linked to multiple OCD ``OfficeTerm`` objects.
-    - ``<Start_Date>`` on VIP's ``<Term>`` maps to ``start_date`` on OCD's ``OfficeTerm``.
-    - ``<End_Date>`` on VIP's ``<Term>`` maps to ``end_date`` on OCD's ``OfficeTerm``.
-    - If ``<Type>`` on VIP's ``<Term>`` is "unexpired-term", then ``previous_term_unexpired`` on OCD's ``OfficeTerm`` should be ``true``. Otherwise, ``previous_term`` should be ``false``.
-
-* VIP fields not implemented in this OCDEP:
-  
-  - ``<Description>`` on ``<Office>`` is optional text.
-  - ``<IsPartisan>`` on ``<Office>`` is an optional boolean.
 
 
 Party

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -96,7 +96,7 @@ Sample Election
 .. code:: javascript
 
     {
-        "id": ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "name": "2016 GENERAL",
         "description": "",
         "start_time": "2016-11-08T00:00:00Z",

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -9,7 +9,7 @@ OCDEP: Elections
 Overview
 ========
 
-Definition of data types to model elections and political contests they are held in order to decided.
+Definition of data types to model elections, candidacies for public office and ballot measures.
 
 The proposed data types are:
 
@@ -22,23 +22,16 @@ The proposed data types are:
     - ``RetentionContest``
 
 * ``Candidacy``
+* ``OfficeTerm``
 * ``Party``
-* ``BallotSelection``, a base class for:
-
-    - ``BallotMeasureSelection``
-    - ``CandidateSelection``
-    - ``PartySelection``
 
 Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton.
 
 Definitions
 ===========
 
-Ballot
-    An official form containing all available selections in each contest in which a voter may vote in an election.
-
 Ballot Measure
-    A proposition (aka, "question") included on the ballot of an election so as to be approved or rejected directly by voters. These propositions include:
+    A proposition or question with two or more predetermined options that voters may select as part of an election. These include:
 
     * The enactment or repeal of a statute, constitutional amendment or other form of law.
     * Approval or rejection of a new tax or additional spending of public funds.
@@ -48,51 +41,45 @@ Candidacy
     The condition of a person being a candidate. A single person may have multiple candidacies if:
 
     * The person competed to hold multiple public offices, even in the same election.
-    * The person competed to hold the same public office in more than one election. This includes:
-
-        - A person who is elected to a public office, serves a full term and runs for re-election as an incumbent candidate.
-        - A person who wins a contest to become a nominee for a public office (known as a "primary election" in U.S. politics) who advances to the final contest of candidates (aka, the "general election").
+    * The person was elected to serve a term in a public office and later sought re-election to the same public office.
 
 Candidate
-    A person competing to be elected to hold a particular public office.
+    A person competing to serve a term in a public office.
 
 Contest
-    A specific decision with a set of predetermined options (aka, "selections") put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
+    A specific decision with a set of predetermined options put before voters in an election. These contests include:
+
+    * Selecting candidates to serve terms in public offices.
+    * Selecting options set forth in a ballot measure.
+    * Selecting a preferred political party to hold power.
 
 Election
-    A collection of political contests decided in parallel through a process of compiling official ballots cast by voters and adding up the total votes for each selection in each contest.
+    A collection of political contests held within a political geography that are decided in parallel through a process of compiling official ballots cast by voters and adding up the total votes for each selection in each contest.
 
 Election Day
     The final or only date when eligible voters may cast their ballots in an election. Typically this is also the same date when results of the election's contests are first publicly reported.
 
 Incumbent
-    The candidate for a public office who also currently holds that public office.
+    The candidate for a public office who also currently holds that public office. Also applies to the political party that currently holds majority power.
+
+Office Term
+    The interval in which an elected candidate is expected to retain a public office before being re-elected or replaced.
+
+    For a variety of reasons, an office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
 
 Party
-    A political organization to which public office holders and candidates can be affiliated.
+    A political organization to which public office holders and candidates can be affiliated. In some electoral systems, such as `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_, voters may also directly elect political parties to hold power in lieu of or in addition to specific candidates endorsed by the political party.
 
 Public Office
     A position within a governmental body which is filled through an election contest.
 
 Runoff Contest
-    A contest conducted to decide a previous contest in which no single selection received the required number of votes to decide the contest.
-
-Selection
-    A predetermined option that voters could select on a ballot in an election contest.
-
-Term of Office
-    The period of time a person elected to a public office is expected retain the position before being re-elected or replaced.
-
-    For a variety of reasons, an office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
+    A contest conducted to decide a previous contest in which no single option received the required number of votes to decide the contest.
 
 Ticket
-    Two or more allied candidates competing together in the same contest fill two or more public offices. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
+    Two or more allied candidates competing together in the same contest where terms in multiple related public offices are at stake. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
 
-Vote
-    A specific selection selected by a voter on a ballot in an election contest.
-
-Voter
-    A person who is eligible to vote in an election.
+    Note that candidates on the same ticket are not necessarily affiliated with the same political party.
 
 Write-in
     A vote in a contest wherein the voter explicitly names a preferred selection for an election contest, rather than choosing from among the predetermined selections listed on the ballot.
@@ -119,11 +106,14 @@ VIP 5, the specification's current version, incorporates elements from the `Elec
 Differences from VIP
 ++++++++++++++++++++
 
-Each of the data types described in this proposal corresponds to an element described in the VIP's current `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_. While interoperability with VIP data is a goal of this proposal, there is not a one-to-one mapping between the tags within a VIP element and the properties of its corresponding data type in this OCDEP.
+The two major differences are:
+
+1. VIP models a single election, whereas this proposal intends to model previous and pending elections. As such, certain OCD data types are independent of and linked to multiple elections and/or election contests, unlike their corresponding VIP elements. 
+2. VIP models finer details about an election, including where voters can vote and the exact wording of their ballots. These details are beyond the scope of this proposal, which is more focused on representing the distinct election contests and their potential outcomes.
 
 Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 
-One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
+Additionally, VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
 
 Implementation
 ==============
@@ -131,11 +121,9 @@ Implementation
 Election
 ---------
 
-A collection of political contests set to be decided on the same date.
+A collection of political contests set to be decided on the same date within a political geography (aka, ``Division``).
 
-``Election`` is a subclass of OCD's ``Event`` data type, defined in `OCDEP 4: Events <http://opencivicdata.readthedocs.io/en/latest/proposals/0004.html>`_, which was accepted in June 2014. All of core and optional properties of ``Event`` are inherited by ``Election``.    
- 
-The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
+``Election`` is a subclass of OCD's ``Event`` data type, defined in `OCDEP 4: Events <http://opencivicdata.readthedocs.io/en/latest/proposals/0004.html>`_, which was accepted in June 2014. All of the required and optional properties of ``Event`` are inherited by ``Election``. The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
 
 identifiers
     **optional**
@@ -143,7 +131,7 @@ identifiers
     Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
 
 division_id
-    Reference to the OCD ``Division`` that defines the broadest geographical scope of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
+    Reference to the OCD ``Division`` that defines the broadest political geography of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
 
 administrative_organization_id
     **optional**
@@ -178,12 +166,11 @@ Sample Election
         "name": "2016 GENERAL",
         "description": "",
         "start_time": "2016-11-08T00:00:00Z",
-        "division_id": 'ocd-division/country:us/state:ca/',
         "end_time": null,
         "timezone": "US/Pacific",     
         "all_day": true,      
         "classification": "election",
-        "division_id": 'ocd-division/country:us/state:ca/'
+        "division_id": "ocd-division/country:us/state:ca/",
         "administrative_organization_id": "ocd-organization/436b4d67-b5aa-402c-9e20-0e56a8432c80",
         "created_at": "2017-02-07T07:17:58.874Z",
         "updated_at": "2017-02-07T07:17:58.874Z",
@@ -208,8 +195,8 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<Name>`` is not required on VIP, but ``name`` is required on OCD's ``Event``.
-    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, maps to ``division_id``. If ``<IsStatewide>`` is true on the VIP election, then ``division_id`` will reference the same state. Otherwise, it should reference one of the state's subdivisions.
+    - ``<Name>`` is not required on VIP's ``<Election>``, but ``name`` (inherited from OCD's ``Event``) is required.
+    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, should map to an equivalent OCD ``division_id`` if ``<IsStatewide>`` is ``true``. Otherwise, ``division_id`` should reference the appropriate subdivision of the equivalent to ``<StateId>``.
 
 * OCD fields not implemented in VIP:
 
@@ -228,9 +215,8 @@ Mapping to VIP
 
     - ``<ElectionType>``, which is an optional string that conflates the level of government to which a candidate might be elected (e.g., "federal", "state", "county", etc.) with the point when the election occurs in the overall cycle (e.g., "general", "primary", "runoff" and "special").
     - ``<HoursOpenId>``, which is an optional reference to a VIP `<HoursOpen> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/hours_open.html>`_ element that represents when polling locations for the election are generally open.
-    - ``<IsStatewide>``, which is an optional boolean.
     - ``<RegistrationInfo>``, which is an optional string.
-    - ``<RegistrationDeadline>`, which is an optional date.
+    - ``<RegistrationDeadline>``, which is an optional date.
     - ``<HasElectionDayRegistration>``, which is an optional boolean.
     - ``<AbsenteeBallotInfo>``, which is an optional string.
     - ``<AbsenteeRequestDeadline>``, which is an optional date.
@@ -240,7 +226,7 @@ Mapping to VIP
 Contest
 -------
 
-A base class representing a specific decision set before voters in an election. Includes properties shared by all contest types: ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` and ``RetentionContest``.
+A base class for representing a specific decision set before voters in an election. Includes properties shared by all contest types: ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` and ``RetentionContest``.
 
 id
     Open Civic Data-style id in the format ``ocd-contest/{{uuid}}``.
@@ -254,7 +240,7 @@ name
     Name of the contest, not necessarily as it appears on the ballot (string).
 
 division_id
-    Reference to the OCD ``Division`` that defines the geographical scope of the contest, e.g., a specific Congressional or State Senate district. The ``Division`` referenced by each ``Contest`` should be a subdivision of the ``Divsion`` referenced by its ``Election``.
+    Reference to the OCD ``Division`` that defines the political geography of the contest, e.g., a specific Congressional or State Senate district. The ``Division`` referenced by each ``Contest`` should be a subdivision of the ``Division`` referenced by its ``Election``.
 
 election_id
     Reference to the OCD ``Election`` in which the contest is decided.
@@ -311,7 +297,7 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<ElectoralDistrictId>``, which is an optional reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, is replaced by ``division_id``, which is a required reference to an OCD ``Division``.
+    - ``<ElectoralDistrictId>``, which is an optional reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, can map to an equivalent OCD ``division_id``.
 
 * OCD fields not implemented in VIP:
 
@@ -319,42 +305,29 @@ Mapping to VIP
 
 * VIP fields not implemented in this OCDEP:
 
-    - ``Abbreviation``, which is an optional string.
-    - ``<BallotSelectionIds>``, which is an optional single element that contains a set of references to ballot selections for the contest. Instead, ``BallotSelection`` includes a single, required ``contest_id``.
-    - ``<ElectorateSpecification>``, which an optional string.
+    - ``<Abbreviation>``, which is an optional string.
+    - ``<BallotSelectionIds>`` is an optional single element that contains a set of references to each selection (i.e., any extension of VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_) on any ballot that includes the contest. This proposal instead implements properties on the subclasses of ``Contest`` for storing the distinct options for each contest across all versions of the ballot (e.g., the ``BallotMeasureContest.options`` and ``CandidateContest.candidacies`` properties).
+    - ``<ElectorateSpecification>``, which optional text.
     - ``<HasRotation>``, which is an optional boolean.
-    - ``<BallotSubTitle>``,  which is an optional string.
-    - ``<BallotTitle>``,  which is an optional string.
+    - ``<BallotSubTitle>``,  which is optional text.
+    - ``<BallotTitle>``,  which is optional text.
     - ``<SequenceOrder>``,  which is an optional integer.
     - ``<VoteVariation>``,  which is an optional reference to a VIP `<VoteVariation> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/vote_variation.html>`_.
-    - ``<OtherVoteVariation>``, which is an optional string.
+    - ``<OtherVoteVariation>``, which is optional text.
 
 
 BallotMeasureContest
 --------------------
 
-A subclass of ``Contest`` for representing a ballot measure before the voters, including summary statements on each side. Inherits all of the required and optional properties of ``Contest``.
+A subclass of ``Contest`` for representing a ballot measure before the voters, including options voters may select. Inherits all the required and optional properties of ``Contest``.
 
+options
+    **repeated**
+    List of the options voters may choose, e.g., "yes", "no", "recall", "no recall" (two or more required).
 
-summary
+description
     **optional**
-    Short summary of the ballot measure that is on the ballot, below the title, but above the text.
-
-text
-    **optional**
-    The full text of the ballot measure as it appears on the ballot (string).
-
-support_statement
-    **optional**
-    A statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
-
-oppose_statement
-    **optional**
-    A statement in opposition to the ballot measure. It does not necessarily appear on the ballot (string).
-
-effect_of_abstain
-    **optional**
-    Specifies the effect abstaining from voting on the ballot measure, i.e., whether abstaining is considered a vote against it (string).
+    Text describing the purpose and/or potential outcomes of the ballot measure, not necessarily as it appears on the ballot (string).
 
 requirement
     **optional**
@@ -363,6 +336,10 @@ requirement
 classification
     **optional**
     Describes the origin and/or potential outcome of the ballot measure, e.g., "initiative statute", "legislative constitutional amendment" (string).
+
+runoff_for_contest_id
+    **optional**
+    If this contest is a runoff to determine the outcome of a previously undecided contest, reference to that ``BallotMeasureContest``.
 
 
 Sample BallotMeasureContest
@@ -391,13 +368,14 @@ Sample BallotMeasureContest
             }
         ],
         "extras": {},
-        "support_statement": "",
-        "oppose_statement": "",
-        "effect_of_abstain": "",
-        "text": "",
+        "options": [
+            "yes",
+            "no"
+        ],
+        "description": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
         "requirement": "50% plus one vote",
-        "summary": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
-        "classification": "initiative statute"
+        "classification": "initiative statute",
+        "runoff_for_contest_id": null
     }
 
 
@@ -408,42 +386,47 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<ConStatement>`` maps to ``oppose_statement``.
-    - ``<ProStatement>`` maps to ``support_statement``.
     - ``<PassageThreshold>`` maps to ``requirement``.
     - ``<Type>``, which is an optional reference to a VIP `<BallotMeasureType> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/ballot_measure_type.html#multi-xml-ballot-measure-type>`_ maps to ``classification`` which is a simple string.
 
+* OCD fields not implemented in VIP:
+
+    - ``options`` should list the distinct selections across all ballots that include the ``<BallotMeasureContest>`` (i.e., the ``<Selection>`` tag in the `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+
 * VIP fields not implemented in this OCDEP:
 
+    - ``<ConStatement>``, which is optional text.
+    - ``<ProStatement>``, which is optional text.
+    - ``<EffectOfAbstain>``, which is optional.
+    - ``<FullText>``, which is optional text.
+    - ``<SummaryText>``, which is optional text.
     - ``<InfoUri>``, which is optional.
-    - ``<OtherType>``, which is optional.
+    - ``<OtherType>``, which is optional text.
+
 
 CandidateContest
 ----------------
 
-A subclass of ``Contest`` for repesenting a contest among candidates competing for election to a public office. Inherits all of the required and optional properties of ``Contest``.
-
-filing_deadline
-    **optional**
-    Specifies the date and time when a candidate must have filed for the contest for the office (datetime). This date is considered to be in the timezone local to the contest's division.
-
-is_unexpired_term
-    Indicates that the former public office holder vacated the post before serving a full term (boolean).
+A subclass of ``Contest`` for repesenting a contest among candidates seeking for election to one or more public offices. Inherits all the required and optional properties of ``Contest``.
 
 number_elected
     **optional**
     Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
 
-post_ids
+office_terms
     **repeated**
-    Lists each identifier of an OCD ``Post`` representing a public office for which the candidates are competing in the contest. Has the following properties:
+    List of references to each OCD ``OfficeTerm`` representing a term of public office for which the candidates in the contest are seeking election. Requires at least one. Has the following properties:
 
-        post_id
-            Reference to an OCD ``Post``.
+    office_term_id
+        Reference to an OCD ``OfficeTerm``.
 
-        sort_order
-            **optional**
-            Useful for sorting posts in contests where two or more public offices are at stake, e.g., in a U.S. presidential contest, the President post would have a lower sort order than the Vice President post.
+    sort_order
+        **optional**
+        Useful for sorting for contests where two or more public offices are at stake, e.g., in a U.S. presidential contest, the President post would have a lower sort order than the Vice President post.
+
+candidacy_ids
+    **repeated**
+    List of references to each candidacy for one of the public office terms at stake in the contest. Requires at least one.
 
 party_id
     **optional**
@@ -475,12 +458,16 @@ Sample CandidateContest
             }
         ],
         "extras": {},
-        "filing_deadline": 2016-06-07,
-        "posts": [
+        "office_terms": [
             {
-                "id": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
+                "office_term_id": "ocd-officeterm/08d670db-72cb-495b-afdd-f7f91794ad8d",
                 "sort_order": 0
             }
+        ],
+        "candidacy_ids": [
+            "ocd-candidacy/153344e1-e533-4a05-880c-a332038cb785",
+            "ocd-candidacy/e029a7a6-665a-4b7b-82f7-1ab554905518",
+            "ocd-candidacy/355e4858-847c-4cf5-88d6-c8d1de167e07"
         ],
         "is_unexpired_term": false,
         "number_elected": 1,
@@ -496,18 +483,12 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, is replaced by ``post_ids``, which is a repeated field that requires at least one reference to an OCD ``Post``. In VIP, the primary office should be listed first. In OCD, the primary post should have ``is_primary`` set to true.
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, should each map to an OCD ``OfficeTerm``. The order in which the OfficeIds are listed should be preserved in ``sort_order``.
 
 * OCD fields not implemented in VIP:
 
-    - required:
-
-        + ``is_unexpired_term`` could be inferred from ``<Name>`` or ``<ElectionType>`` tags (e.g., for U.S. elections, these tags would likely include "special") or from the date of the election.
-
-    - optional:
-
-        + ``filing_deadline`` is stored in the `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element in VIP.
-        + ``runoff_for_contest_id`` is the id of the ``CandidateContest`` with the same ``post_ids`` and ``party_id`` values occurring on the previous election date.
+    + ``candidacy_ids`` should list the distinct candidate selections across all ballots that include the ``<CandidateContest>`` (i.e., each OCD ``Candidacy`` equivalent to each VIP ``<Candidate>`` referenced in the ``<CandidateIds>`` tag in the `<CandidateSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+    + ``runoff_for_contest_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:
 
@@ -517,21 +498,74 @@ Mapping to VIP
 PartyContest
 ------------
 
-A subclass of ``Contest`` which represents a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States). Inherits all of the required and optional properties of ``Contest``.
+A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of or in addition to candidates for public office endorsed by that party (as in the case of `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_ ). Inherits all the required and optional properties of ``Contest``.
+
+parties
+    **repeated**
+    List of references to each OCD ``Party`` for which a voter could vote in the election contest. Requires at list one. Has the following properties:
+
+    party_id
+        Reference to an OCD ``Party``.
+
+    is_incumbent
+        **optional**
+        Indicates whether the party currently holds majority power (boolean).
+
+runoff_for_contest_id
+    **optional**
+    If this contest is a runoff to determine the outcome of a previously undecided contest, reference to that ``PartyContest``.
+
+
+Sample PartyContest
++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
+        "identifiers": [],
+        "name": "",
+        "division_id": "ocd-division/country:us/state:ca/sldu:1",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "created_at": "2017-02-07T07:18:05.438Z",
+        "updated_at": "2017-02-07T07:18:05.442Z",
+        "sources": [],
+        "extras": {},
+        "parties": [
+            {
+                "party_id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1",
+                "is_incumbent": false
+            },
+            {
+                "party_id": "ocd-organization/b58f698e-a956-4bd5-8ca1-3b46c22c96b4",
+                "is_incumbent": true
+            },
+        ],
+        "runoff_for_contest_id": null
+    }
+
 
 Mapping to VIP
 ++++++++++++++
 
-``PartyContest`` corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element. The two have no significant differences.
+``PartyContest`` corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element. 
+
+* OCD fields not implemented in VIP:
+    
+    - ``parties`` should list the distinct party selections across all ballots that include the ``<PartyContest>`` (i.e., each OCD ``Party`` equivalent to each VIP ``<Party>`` referenced in the ``<PartyIds>`` tag in the `<PartySelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+    - ``runoff_for_contest_id`` an optional field.
 
 
 RetentionContest
 ----------------
 
-A subclass of ``BallotMeasureContest`` that represents a contest where a person is retains or loses a public office, e.g. a judicial retention or recall election. Inherits all of the required and optional properties of ``BallotMeasureContest``.
+A subclass of ``BallotMeasureContest`` that represents a contest where voters vote to retain or recall a current office holder, e.g. a judicial retention or recall election. Inherits all the required and optional properties of ``BallotMeasureContest``.
+
+In a ``RetentionContest``, voters typically have two options (e.g., "yes" or "no", "recall" or "don't recall"), unlike in a ``CandidateContest`` where voters can choose from among multiple different candidates.
 
 membership_id
-    Reference to the OCD ``Membership`` that represents the tenure of a particular person (i.e., OCD ``Person`` object) in a particular public office (i.e., ``Post`` object).
+    Reference to the OCD ``Membership`` that represents the tenure of a specific person (i.e., OCD ``Person`` object) in a specific public office (i.e., ``Post`` object).
 
 
 Sample RetentionContest
@@ -560,12 +594,12 @@ Sample RetentionContest
             }
         ],
         "extras": {},
-        "support_statement": "",
-        "oppose_statement": "",
-        "effect_of_abstain": "",
-        "requirement": "",
-        "summary": "SHALL GRAY DAVIS BE RECALLED (REMOVED) FROM THE OFFICE OF GOVERNOR?",
-        "text": "",
+        "requirement": "50% plus one vote",
+        "options": [
+            "yes",
+            "no"
+        ],
+        "description": "SHALL GRAY DAVIS BE RECALLED (REMOVED) FROM THE OFFICE OF GOVERNOR?",
         "classification": "recall",
         "other_type": "",
         "membership_id": "ocd-membership/181a0826-f458-403f-ae65-e1ce97b8dd34"
@@ -579,29 +613,25 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, and ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, are replaced by ``membership_id``, which is a required reference to an OCD ``Membership`` representing a particular person's tenure in a particular public office.
-
-* VIP fields not implemented in this OCDEP:
-
-    - ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_. VIP's ``<Office>`` element corresponds to OCD's ``Post`` data type. In this proposal, a candidate's ``post_id`` is stored on ``Candidacy``, including .
-
+    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, and ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, should map to an equivalent OCD ``Membership`` representing a specific person's (i.e, an OCD ``Person`` object) tenure in a specific public office (i.e., an OCD ``Post`` object).
 
 Candidacy
 ---------
 
-Represents a person who is a candidate in a particular ``CandidateContest``. If a candidate is running in multiple contests, each contest must have its own ``Candidate`` object. ``Candidate`` objects may not be reused between contests.
+A person competing to serve a term in a specific public office.
 
 id
     Open Civic Data-style id in the format ``ocd-candidacy/{{uuid}}``.
 
-ballot_name
-    The candidate's name as it will be displayed on the official ballot, e.g. "Ken T. Cuccinelli II" (string).
-
 person_id
     Reference to an OCD ``Person`` who is the candidate.
 
-post_id
-    References the ``Post`` that represents the public office for which the candidate is competing.
+office_term_id
+    Reference to the OCD ``OfficeTerm`` representing the term of public office for which the candidate is seeking election.
+
+candidate_name
+    **optional**
+    For preserving the candidate's name as it was when the person sought election to hold the public office term, which may differ from the person's current name (string).
 
 committee_id
     **optional**
@@ -609,15 +639,19 @@ committee_id
 
 filed_date
     **optional**
-    Specifies when the candidate filed for the contest (date). This is considered to be in the timezone local to contest's division.
+    Specifies when the candidate filed for the contest (date).
 
 is_incumbent
     **optional**
-    Indicates whether the candidate is the incumbent for the office associated with the contest (boolean).
+    Indicates whether the candidate is seeking re-election a public office he/she currently holds (boolean).
 
 party_id
     **optional**
     Reference to and OCD ``Party`` with which the candidate is affiliated.
+
+top_ticket_candidacy_id
+    **optional**
+    If the candidate is running as part of ticket, e.g., a Vice Presidential candidate running with a Presidential candidate, reference to candidacy at the top of the ticket.
 
 created_at
     Specifies when this object was created in the system (datetime).
@@ -648,14 +682,13 @@ Sample Candidacy
 
     {
         "id": "ocd-candidacy/054f0a6e-9c06-4611-8c2c-3e143843c9d8",
-        "ballot_name": "ROWEN, ROBERT J.",
+        "candidate_name": "ROWEN, ROBERT J.",
         "person_id": "ocd-person/edfafa56-686d-49ea-80e5-64bc795493f8",
-        "post_id": "ocd-post/0f169eea-0ad6-48c2-8bc5-ca86e08643d0",
         "committee_id": null,
         "filed_date": 2016-03-10,
-        "ballot_selection_id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f",
         "is_incumbent": false,
-        "party_id": 'ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1',
+        "party_id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1",
+        "top_ticket_candidacy_id": null,
         "created_at": "2017-02-08T04:17:30.818Z",
         "updated_at": "2017-02-08T04:17:30.818Z",
         "sources": [],
@@ -669,26 +702,106 @@ Mapping to VIP
 ``Candidacy`` corresponds to VIP's `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element.
 
 * Important differences between corresponding fields:
-
-    - ``party_id`` is an optional reference an OCD ``Party``, not a VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element.
-    - ``person_id`` is a required reference an OCD ``Person``, not a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_ element.
+  
+    - ``<PartyId>``, which is an optional reference a VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element, can map to an equivalent OCD ``Party``.
+    - ``person_id`` , which is an optional reference a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_ element, can map to an equivalent OCD ``Person``.
+    - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates, is replaced by an optional ``top_ticket_candidacy_id``. 
 
 * OCD fields not implemented in VIP:
-
-    - required:
       
-        + ``post_id`` is required to link the candidate to the public office for which they are competing. In VIP, this is represented as an `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, which is stored on the ``<CandidateContest>`` element.
-
-    - optional:
-      
-        + ``committee_id``
+    - ``committee_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:
 
-    - ``<ContactInformation>`` refers to an element that describes the contact of physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be found on the associated ``Person`` or ``Committee`` object.
+    - ``<ContactInformation>`` refers to an element that describes the contact and physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be stored on the associated ``Person`` or ``Committee`` object.
     - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_.
     - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_.
-    - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates. OCD relies on the ``candidacies`` property of ``CandidateSelection`` to represent the ticket and the ``sort_order`` property of each ``post_id`` listed on ``CandidateContest`` to indicate which candidates are running and the top of their respective tickets.
+
+
+OfficeTerm
+----------
+The interval in which an elected candidate is expected to hold a public office before being re-elected or replaced.
+
+id
+    Open Civic Data-style id in the format ``ocd-officeterm/{{uuid}}``.
+
+post_id
+    Reference to the OCD ``Post`` representing the public office held for the interval.
+
+start_date
+    Date the office holder's term is expected to start. Not necessarily the same as the date when the person began serving in the office (as in the case of a re-election).
+
+end_date
+    Date the office holder's term is expected to end. Not necessarily the same as the date when the office holder vacated the office.
+
+previous_term_unexpired
+    Indicates the previous public office holder vacated the post before serving a full term (boolean).
+
+filing_deadline
+    **optional**
+    Specifies the date and time by when persons must of official filed their candidacies for election or re-election (datetime).
+
+created_at
+    Specifies when this object was created in the system (datetime).
+
+updated_at
+    Specifies when this object was last updated in the system (datetime).
+
+sources
+    **optional**
+    **repeated**
+    List of sources used in assembling this object. Has the following properties:
+
+    url
+        URL of the resource.
+    note
+        **optional**
+        Description of what this source was used for.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+Sample OfficeTerm
++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-officeterm/08d670db-72cb-495b-afdd-f7f91794ad8d",
+        "post_id": "ocd-post/f204b117-24af-42fd-a3fc-c5772533fdf5",
+        "filing_deadline": "2016-09-01T01:01:00.000Z",
+        "start_date": "2017-01-04",
+        "end_date": "2021-01-04",
+        "pervious_term_unexpired": false,
+        "created_at": "2017-02-07T16:36:12.497Z",
+        "updated_at": "2017-02-07T16:36:12.497Z",
+        "sources": [],
+        "extras": {}
+    }
+
+
+Mapping to VIP
+++++++++++++++
+
+``Post`` and ``OfficeTerm`` correspond to VIP's `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ and `<Term> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html#term>`_ elements.
+
+* Important differences between corresponding fields:
+  
+    - ``<Name>`` on VIP's ``<Office>`` maps to ``label`` on OCD's ``Post``.
+    - ``<ElectoralDistrictId>`` on VIP's ``<Office>``, which is a required reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, should map to an equivalent OCD ``division_id``.
+    - ``<ContactInformation>`` on VIP's ``<Office>`` maps to the ``contact_details`` on OCD's ``Post``.
+    - ``<OfficeHolderPersonIds>`` on VIP's ``<Office>`` is an optional single tag that contains a set of references  to each office holder represented, as a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_. Each of these can map to an equivalent OCD ``Membership`` (i.e., a combination of a ``Person``/``Post``/``Organization``).
+    - A VIP ``<Office>`` can only have a single ``<Term>``, but an OCD ``Post`` can be linked to multiple OCD ``OfficeTerm`` objects.
+    - ``<Start_Date>`` on VIP's ``<Term>`` maps to ``start_date`` on OCD's ``OfficeTerm``.
+    - ``<End_Date>`` on VIP's ``<Term>`` maps to ``end_date`` on OCD's ``OfficeTerm``.
+    - If ``<Type>`` on VIP's ``<Term>`` is "unexpired-term", then ``previous_term_unexpired`` on OCD's ``OfficeTerm`` should be ``true``. Otherwise, ``previous_term`` should be ``false``.
+
+* VIP fields not implemented in this OCDEP:
+  
+  - ``<Description>`` on ``<Office>`` is optional text.
+  - ``<IsPartisan>`` on ``<Office>`` is an optional boolean.
 
 
 Party
@@ -696,7 +809,7 @@ Party
 
 A political party with which office holders and candidates may be affiliated.
 
-``Party`` is a subclass of OCD's ``Organization`` data type, defined in `OCDEP 5: People, Organizations, Posts, and Memberships <http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html>`_, which was accepted in June 2014. All of core and optional properties of ``Organization`` are inherited by ``Party``.
+``Party`` is a subclass of OCD's ``Organization`` data type, defined in `OCDEP 5: People, Organizations, Posts, and Memberships <http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html>`_, which was accepted in June 2014. All of required and optional properties of ``Organization`` are inherited by ``Party``.
 
 abbreviation
     **optional**
@@ -724,14 +837,12 @@ Sample Party
         "parent": null,
         "jurisdiction": null,
         "classification": "party",
-        "founding_date": "",
-        "dissolution_date": "",
+        "founding_date": null,
+        "dissolution_date": null,
         "identifiers": [],
         "other_names": [],
         "contact_details": [],
         "links": [],
-        "memberships": [],
-        "posts": [],
         "abbreviation": "D",
         "color": "1d0ee9",
         "is_write_in": false,
@@ -749,162 +860,22 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``name`` is required.
+    - ``<Name>`` is not required on VIP's ``<Party>``, but ``name`` (inherited from OCD's ``Organization``) is required.
+
+* OCD fields not implemented in VIP:
+
+    - ``classification`` (inherited from ``Organization``) should be "party".
+    - ``parent`` (inherited from ``Organization``) is optional.
+    - ``jurisdiction`` (inherited from ``Organization``) is optional.
+    - ``founding_date`` (inherited from ``Organization``) is optional.
+    - ``dissolution_date`` (inherited from ``Organization``) is optional.
+    - ``other_names`` (inherited from ``Organization``) is optional.
+    - ``contact_details`` (inherited from ``Organization``) is optional.
+    - ``links`` (inherited from ``Organization``) is optional.
 
 * VIP fields not implemented in this OCDEP:
   
-    - ``logo_uri``, which is optional.
-
-
-BallotSelection
----------------
-
-A base class representing a predetermined option on a ballot that voters could select in an election contest. Includes the properties shared by all ballot selection types: ``BallotMeasureSelection``, ``CandidateSelection`` and ``PartySelection``.
-
-id
-    Open Civic Data-style id in the format ``ocd-ballotselection/{{uuid}}``.
-
-created_at
-    Time that this object was created at in the system.
-
-updated_at
-    Time that this object was last updated in the system.
-
-extras
-    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
-
-
-Sample BallotSelection
-++++++++++++++++++++++
-
-
-.. code:: javascript
-
-    {
-        "id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f"
-        "created_at": "2017-02-08T04:17:30.817Z",
-        "updated_at": "2017-02-08T04:17:30.817Z",
-        "extras": {}
-    }
-
-
-Mapping to VIP
-++++++++++++++
-
-``BallotSelection`` corresponds to VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_ element.
-
-VIP includes ``<SequenceOrder>``, which is an optional integer that is not implemented in this proposal.
-
-
-BallotMeasureSelection
-----------------------
-
-A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a ballot measure contest, e.g., "yes" or "no". Inherits all of the required and optional properties of ``BallotSelection``.
-
-selection
-    Selection text for the option on the ballot, e.g., "Yes", "No", "Recall", "Don't recall" (string).
-
-contest_id
-    References the ``BallotMeasureContest`` in which the ballot selection is an option.
-
-
-Sample BallotMeasureSelection
-+++++++++++++++++++++++++++++
-
-
-.. code:: javascript
-
-    {
-        "id": "ocd-ballotselection/85399ed5-b91d-4a7c-a868-dd152ce28ed4",
-        "contest_id": "ocd-contest/2ce7e19b-3feb-4318-9908-eb3fdf456fb0",
-        "selection": "Yes",
-        "created_at": "2017-02-08T04:17:24.486Z",
-        "updated_at": "2017-02-08T04:17:24.486Z",
-        "extras": {}
-    }
-
-
-Mapping to VIP
-++++++++++++++
-
-``BallotMeasureSelection`` corresponds to VIP's `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element. There are no significant differences between the two.
-
-
-CandidateSelection
-------------------
-
-A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a candidate contest, e.g., a particular candidate or "ticket". Inherits all of the required and optional properties of ``BallotSelection``.
-
-id
-    Open Civic Data-style id in the format ``ocd-candidateselection/{{uuid}}``.
-
-contest_id
-    References the ``CandidateContest`` in which the ballot selection is an option.
-
-candidacy_ids
-    **repeated**
-    Lists each identifier of an OCD ``Candidacy`` associated with the ballot selection. Requires at least one ``candidacy_id``, but the number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor".
-
-endorsement_party_ids
-    **optional**
-    **repeated**
-    Lists each identifer of an OCD ``Party`` that is endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
-
-is_write_in
-    **optional**
-    Indicates that the particular ballot selection allows for write-in candidates. If true, one or more write-in candidates are allowed for this contest (boolean).
-
-
-Sample CandidateSelection
-+++++++++++++++++++++++++
-
-
-.. code:: javascript
-
-    {
-        "id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f"
-        "contest_id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
-        "candidacy_ids": [
-            "ocd-candidacy/054f0a6e-9c06-4611-8c2c-3e143843c9d8"
-        ],
-        "is_write_in": false,
-        "created_at": "2017-02-08T04:17:30.817Z",
-        "updated_at": "2017-02-08T04:17:30.817Z",
-        "extras": {},
-    }
-
-
-Mapping to VIP
-++++++++++++++
-
-``CandidateSelection`` corresponds to VIP's `<CandidateSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_selection.html>`_ element.
-
-* Important differences between corresponding fields:
-
-    - ``<CandidateIds>``, which is an optional set of references to VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ elements, is replaced by ``candidacy_ids``, which is a repeating field that requires at least one reference to an OCD ``Candidacy``.
-    - ``<EndorsementPartyIds>``, which is an optional set of references to VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ elements, is replaced by ``endorsement_party_ids``, which is an optional repeating field that list references to each OCD ``Party`` endorsing the candidate(s).
-
-
-PartySelection
---------------
-
-A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a party contest. Inherits all of the required and optional properties of ``BallotSelection``.
-
-id
-    Open Civic Data-style id in the format ``ocd-partyselection/{{uuid}}``.
-
-party_ids
-    **repeated**
-    Lists each identifier of an OCD ``Party`` associated with the ballot selection. Requires at least one ``party_id``.
-
-Mapping to VIP
-++++++++++++++
-
-``PartySelection`` corresponds to VIP's `<PartySelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_selection.html>`_ element.
-
-* Important differences between corresponding fields:
-
-    - ``<PartyIds>``, which is an optional, set of references to VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ elements, is replaced by ``endorsement_party_ids``, which is an optional repeating field that list references to each OCD ``Party`` associated with the selection.
+    - ``<LogoUri>``, which is optional.
 
 
 Copyright

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -128,7 +128,7 @@ One general note: VIP describes `<InternationalizedText> <http://vip-specificati
 Questions
 =========
 
-* Should either ``Election`` subclass ``Event``?
+* Should ``Election`` subclass ``Event``?
 * Should ``Contest`` subclass ``VoteEvent``?
 * Should ``Party`` be implemented as an ``Organization`` (or subclass)?
 * Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
@@ -157,7 +157,7 @@ name
 date
     Date on which the election is set to be decided (aka, Election Day). This tends to be the last day when voters can cast their ballots and the first day when the election's results a publicly reported (date).
 
-    This date should be considered to be in the timezone local to the election's division.
+    This date is considered to be in the timezone local to the election's division.
 
 division_id
     Reference to the OCD ``Division`` that defines the broadest geographical scope of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
@@ -436,7 +436,7 @@ A subclass of ``Contest`` for repesenting a contest among candidates competing f
 
 filing_deadline
     **optional**
-    Specifies the date and time when a candidate must have filed for the contest for the office (datetime).
+    Specifies the date and time when a candidate must have filed for the contest for the office (datetime). This date is considered to be in the timezone local to the contest's division.
 
 is_unexpired_term
     Indicates that the former public office holder vacated the post before serving a full term (boolean).
@@ -620,7 +620,7 @@ committee_id
 
 filed_date
     **optional**
-    Specifies when the candidate filed for the contest (date).
+    Specifies when the candidate filed for the contest (date). This is considered to be in the timezone local to contest's division.
 
 is_incumbent
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -430,8 +430,7 @@ previous_term_unexpired
     Indicates the previous public office holder vacated the post before serving a full term (boolean).
 
 number_elected
-    **optional**
-    Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
+    Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer). Default is 1.
 
 
 runoff_for_contest_id
@@ -482,6 +481,7 @@ Mapping to VIP
 
     - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>`` should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
     - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Party``.
+    - ``<NumberElected>`` is an optional integer in VIP but not in OCD, where it defaults to 1.
 
 * OCD fields not implemented in VIP:
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -157,7 +157,7 @@ full_text
 
 passage_threshold
     **optional**
-    Specifies the threshold of votes the ballot measure needs in order to pass. The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
+    Specifies the threshold of votes the ballot measure needs in order to pass (string). The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
 
 pro_statement
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -534,12 +534,12 @@ Corresponds to VIP's `<CandidateContest> <http://vip-specification.readthedocs.i
 
     - required:
 
-        + ``is_runoff`` could be determined by the ``<ElectionType>`` or inferred from the date of the election.
         + ``is_unexpired_term`` could be determined by the ``<Name>`` or ``<ElectionType>`` (i.e., if either include the substring "special") or inferred from the date of the election.
 
     - optional:
 
         + ``filing_deadline`` is stored in the `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element in VIP.
+        + ``runoff_for_contest_id`` is the id of the ``CandidateContest`` with the same ``post_ids`` and ``party_id`` values occurring on the previous election date.
 
 * VIP fields not implemented in this OCDEP:
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -395,7 +395,7 @@ candidacy_ids
 endorsement_party_ids
     **optional**
     **repeated**
-    Lists each ``Party`` that endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
+    Lists each ``Party`` that is endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
 
 is_write_in
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -242,7 +242,7 @@ name
     Name of the contest, not necessarily as it appears on the ballot (string).
 
 division_id
-    Reference to the OCD ``Division`` that defines the political geography of the contest, e.g., a specific Congressional or State Senate district. The ``Division`` referenced by each ``Contest`` should be a subdivision of the ``Division`` referenced by its ``Election``.
+    Reference to the OCD ``Division`` that defines the political geography of the contest, e.g., a specific Congressional or State Senate district. The ``Division`` referenced by each ``Contest`` should be a subdivision of the ``Division`` referenced by the contest's ``Election``.
 
 election_id
     Reference to the OCD ``Election`` in which the contest is decided.
@@ -409,7 +409,7 @@ Mapping to VIP
 CandidateContest
 ----------------
 
-A subclass of ``Contest`` for repesenting a contest among candidates seeking for election to one or more public offices. Inherits all the required and optional properties of ``Contest``.
+A subclass of ``Contest`` for repesenting a contest among candidates seeking election to one or more public offices. Inherits all the required and optional properties of ``Contest``.
 
 posts
     **repeated**
@@ -632,7 +632,7 @@ contest_id
 
 candidate_name
     **optional**
-    For preserving the candidate's name as it was when the person sought election to hold the public office term, which may differ from the person's current name (string).
+    For preserving the candidate's name as it was of the candidacy. (string).
 
 filed_date
     **optional**
@@ -640,11 +640,11 @@ filed_date
 
 is_incumbent
     **optional**
-    Indicates whether the candidate is seeking re-election a public office he/she currently holds (boolean).
+    Indicates whether the candidate is seeking re-election to a public office he/she currently holds (boolean).
 
 party_id
     **optional**
-    Reference to and OCD ``Party`` with which the candidate is affiliated.
+    Reference to an OCD ``Party`` with which the candidate is affiliated.
 
 top_ticket_candidacy_id
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -25,7 +25,7 @@ The proposed data types are:
 * ``OfficeTerm``
 * ``Party``
 
-Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton.
+Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton, and lays the foundation for a future proposal covering election results.
 
 Definitions
 ===========
@@ -412,10 +412,6 @@ CandidateContest
 
 A subclass of ``Contest`` for repesenting a contest among candidates seeking for election to one or more public offices. Inherits all the required and optional properties of ``Contest``.
 
-number_elected
-    **optional**
-    Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
-
 posts
     **repeated**
     List of references to each OCD ``Post`` representing a public office for which the candidates in the contest are seeking election. Requires at least one. Has the following properties:
@@ -430,6 +426,14 @@ posts
 party_id
     **optional**
     If the contest is among candidates of the same political party, e.g., a partisan primary election, reference to the OCD ``Party`` representing that political party.
+
+previous_term_unexpired
+    Indicates the previous public office holder vacated the post before serving a full term (boolean).
+
+number_elected
+    **optional**
+    Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
+
 
 runoff_for_contest_id
     **optional**
@@ -463,7 +467,7 @@ Sample CandidateContest
                 "sort_order": 0
             }
         ],
-        "is_unexpired_term": false,
+        "previous_term_unexpired": false,
         "number_elected": 1,
         "party_id": null,
         "runoff_for_contest_id": null
@@ -477,10 +481,12 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>``should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>`` should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
+    - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Party``.
 
 * OCD fields not implemented in VIP:
 
+    + ``previous_term_unexpired`` should be ``true`` if the ``<OfficeTermType>`` referenced by the ``<Term>`` tag in VIP's `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element is "unexpired-term". Otherwise, ``previous_term_unexpired`` should be ``false``.
     + ``runoff_for_contest_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -123,7 +123,7 @@ Each of the data types described in this proposal corresponds to an element desc
 
 Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 
-One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``pro_statement`` and ``con_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
+One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
 
 Questions
 =========
@@ -408,15 +408,26 @@ Sample BallotMeasureContest
         "text": "",
         "requirement": "50% plus one vote",
         "summary": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
-        "ballot_measure_type": "initiative statute"
+        "classification": "initiative statute"
     }
 
 
 Mapping to VIP
 ++++++++++++++
 
-``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element. It includes an optional ``<InfoUri>``, which is not implemented in this OCDEP.
+``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element.
 
+* Important differences between corresponding fields:
+
+    - ``<ConStatement>`` maps to ``oppose_statement``.
+    - ``<ProStatement>`` maps to ``support_statement``.
+    - ``<PassageThreshold>`` maps to ``requirement``.
+    - ``<Type>``, which is an optional reference to a VIP `<BallotMeasureType> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/ballot_measure_type.html#multi-xml-ballot-measure-type>`_ maps to ``classification`` which is a simple string.
+
+* VIP fields not implemented in this OCDEP:
+
+    - ``<InfoUri>``, which is optional.
+    - ``<OtherType>``, which is optional.
 
 CandidateContest
 ----------------
@@ -443,7 +454,7 @@ post_ids
 
         sort_order
             **optional**
-            Useful sorting posts in contests where two or more public offices are at stake.
+            Useful for sorting posts in contests where two or more public offices are at stake, e.g., in a U.S. presidential contest, the President post would have a lower sort order than the Vice President post.
 
 party_id
     **optional**
@@ -560,13 +571,13 @@ Sample RetentionContest
             }
         ],
         "extras": {},
-        "con_statement": "",
+        "support_statement": "",
+        "oppose_statement": "",
         "effect_of_abstain": "",
-        "passage_threshold": "",
-        "pro_statement": "",
-        "summary_text": "SHALL GRAY DAVIS BE RECALLED (REMOVED) FROM THE OFFICE OF GOVERNOR?",
-        "full_text": "",
-        "ballot_measure_type": "initiative",
+        "requirement": "",
+        "summary": "SHALL GRAY DAVIS BE RECALLED (REMOVED) FROM THE OFFICE OF GOVERNOR?",
+        "text": "",
+        "classification": "recall",
         "other_type": "",
         "membership_id": "ocd-membership/181a0826-f458-403f-ae65-e1ce97b8dd34"
     }
@@ -688,6 +699,7 @@ Mapping to VIP
     - ``<ContactInformation>`` refers to an element that describes the contact of physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be found on the associated ``Person`` or ``Committee`` object.
     - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_.
     - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_.
+    - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates. OCD relies on the ``candidacies`` property of ``CandidateSelection`` to represent the ticket and the ``sort_order`` property of each ``post_id`` listed on ``CandidateContest`` to indicate which candidates are running and the top of their respective tickets.
 
 
 Party
@@ -898,7 +910,7 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<CandidateIds>``, which is an optional set of references to VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ elements, is replaced by ``candidates``, which is a repeating field that requires at least one reference to an OCD ``Candidacy``.
+    - ``<CandidateIds>``, which is an optional set of references to VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ elements, is replaced by ``candidacy_ids``, which is a repeating field that requires at least one reference to an OCD ``Candidacy``.
     - ``<EndorsementPartyIds>``, which is an optional set of references to VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ elements, is replaced by ``endorsement_party_ids``, which is an optional repeating field that list references to each OCD ``Party`` endorsing the candidate(s).
 
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -1,0 +1,668 @@
+====================
+OCDEP: Elections
+====================
+
+:Created: 2016-12-28
+:Author: James Gordon, Forest Gregg, `California Civic Data Coalition <http://www.californiacivicdata.org/>`_
+:Status: Proposed
+
+Overview
+========
+
+Definition of data types to model elections within which political contests are decided, including relationships to ballot measures and candidates competing for public office.
+
+The proposed data types are:
+
+* ``Election``
+* ``ContestBase``, a base class for:
+
+    - ``BallotMeasureContest``
+    - ``CandidateContest``
+    - ``PartyContest``
+    - ``RetentionContest``
+
+* ``Candidacy``
+* ``Party``
+* ``BallotSelectionBase``, a base class for:
+
+    - ``BallotMeasureSelection``
+    - ``CandidateSelection``
+    - ``PartySelection``
+
+Supplements the "Campaign Finance Filings" proposal being prepared by Abraham Epton.
+
+Rationale
+=========
+
+Elections are a primary focal point of civic activity in which eligible voters cast ballots to determine the outcome of political contests, including:
+
+* Who should hold a public office?
+* Should a proposed change of law be implemented?
+
+Modeling the potential outcomes of these contests is a service to voters who may cast their ballots in an impending election. Modeling the contests' actual outcomes legitimizes the election's results and enables historical electoral analysis.
+
+This proposal is submitted in response to on-going discussion around a related OCDEP focused on campaign-finance disclosures. Representing elections and their contests is necessary for modeling these disclosures because they reveal money raised and spent in support or opposition to specific candidates and ballot measures. However, since notions of elections and their contests run up against other domains, we've separated the definition of these types.
+
+The goal of this proposal is to cover the use cases related to the campaign finance domain while laying the foundation for models that will include election results (to be covered in a future OCDEP).
+
+Our use cases require unique representations of both previous elections and contests as well as pending elections and contests. While honoring these requirements, we also aim for consistency with the Voting Information Project's `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_ so as to support a high degree of interoperability with that existing data standard.
+
+VIP 5, the specification's current version, incorporates elements from the `Election Results Common Data Format Specification <https://www.nist.gov/itl/voting/nist-election-results-common-data-format-specification>`_ defined by the National Institute of Standard and Technology. As such, we have borrowed eagerly from NIST's current specification also.
+
+Important differences between this proposal and the current VIP specification are noted below.
+
+Questions
+=========
+
+* Does ``Election`` need one property (or two properties) to store the election type (e.g., general, primary, special) and/or election level (e.g., federal, state, county, local)? VIP's `<Election> <>`_ element has an `ElectionType` field, but this is just a string that you can apparently populate with whatever.
+* Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But would expect most users typically to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
+* Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
+
+
+Implementation
+==============
+
+Election
+--------
+
+A collection of political contests set to be decided on the same date.
+
+``Election`` is a subclass of OCD's ``Event`` data type, defined in `OCDEP 4: Events <http://opencivicdata.readthedocs.io/en/latest/proposals/0004.html>`_, which was accepted in June 2014. All of core and optional properties of ``Event`` are inherited by ``Election``.
+
+The typical implementation will be an ``all_day`` event witht a "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
+
+id
+    Open Civic Data-style id in the format ``ocd-election/{{uuid}}``.
+
+identifiers
+    **optional**
+    **repeated**
+    Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
+
+administrative_org_id
+    **optional**
+    Reference to the ``Organization`` that administers the election.
+
+state
+    `FIPS code <https://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code>`_ of the state where the election is being held. Recorded in the format ``st{{fips}}`` to match references to VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_  elements (string).
+
+is_statewide
+    **optional**
+    Indicates whether the election is statewide (boolean).
+
+
+ContestBase
+-----------
+
+A base class with the properties shared by all contest types: ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` and ``RetentionContest``.
+
+id
+    Open Civic Data-style id in the format ``ocd-contest/{{uuid}}``.
+
+identifiers
+    **optional**
+    **repeated**
+    Upstream identifiers of the contest if any exist, such as those assigned by a Secretary of State, county or city elections office.
+
+name
+    Name of the contest, not necessarily as it appears on the ballot (string).
+
+division_id
+    Reference to the ``Division`` that defines the geographical scope of the contest, e.g., a specific Congressional or State Senate district.
+
+election_id
+    Reference to the OCD ``Election`` in which the contest is decided.
+
+created_at
+    Time that this object was created at in the system.
+
+updated_at
+    Time that this object was last updated in the system.
+
+sources
+    **optional**
+    **repeated**
+    List of sources used in assembling this object. Has the following properties:
+
+    url
+        URL of the resource.
+    note
+        **optional**
+        Description of what this source was used for.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+BallotMeasureContest
+--------------------
+
+A subclass of ``ContestBase`` for representing a ballot measure before the voters, including summary statements on each side.
+
+id
+    Open Civic Data-style id in the format ``ocd-ballotmeasurecontest/{{uuid}}``
+
+con_statement
+    **optional**
+    Specifies a statement in opposition to the ballot measure. It does not necessarily appear on the ballot (string).
+
+effect_of_abstain
+    **optional**
+    Specifies the effect abstaining from voting on the ballot measure, i.e., whether abstaining is considered a vote against it (string).
+
+full_text
+    **optional**
+    Specifies the full text of the ballot measure as it appears on the ballot (string).
+
+passage_threshold
+    **optional**
+    Specifies the threshold of votes the ballot measure needs in order to pass. The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
+
+pro_statement
+    **optional**
+    Specifies a statement in favor of the referendum. It does not necessarily appear on the ballot (string).
+
+summary_text
+    **optional**
+    Specifies a short summary of the ballot measure that is on the ballot, below the title, but above the text.
+
+type
+    **optional**
+    Enumerated among:
+
+    * ballot-measure: A catch-all for generic types of non-candidate-based contests.
+    * initiative: These are usually citizen-driven measures to be placed on the ballot. These could include both statutory changes and constitutional amendments.
+    * referendum: These could include measures to repeal existing acts of legislation, legislative referrals, and legislatively-referred state constitutional amendments.
+    * other: Anything that does not fall into the above categories.
+
+other_type
+    **optional**
+    Allows for cataloging a new type of ballot measure option, when type is specified as "other" (string).
+
+
+CandidateContest
+----------------
+
+A subclass of ``ContestBase`` for repesenting a contest among candidates competing for election to a public office.
+
+id
+    Open Civic Data-style id in the format ``ocd-candidatecontest/{{uuid}}``.
+
+filing_deadline
+    **optional**
+    Specifies the date and time when a candidate must have filed for the contest for the office (datetime).
+
+is_runoff
+    Indicates a contest to decide a prior contest that ended with no candidate receiving a majority of the votes (boolean).
+
+is_unexpired_term
+    Indicates that the former public office holder vacated the post before serving a full term (boolean).
+
+number_elected
+    **optional**
+    Number of candidates that are elected in the contest, i.e. 'N' of N-of-M (integer).
+
+post_ids
+    **repeating**
+    References to the OCD ``Posts`` representing the public offices for which the candidates are competing. If multiple, the primary post should be listed first, e.g., the id for the President post should be listed before the id for Vice-President.
+
+party_id
+    **optional**
+    If the contest is among candidates of the same political party, e.g., a partisan primary election, reference to the OCD ``Party`` representing that political party.
+
+
+PartyContest
+------------
+
+A subclass of ``ContestBase`` which describes a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States).
+
+id
+    Open Civic Data-style id in the format ``ocd-partycontest/{{uuid}}``.
+
+
+RetentionContest
+----------------
+
+A subclass of ``BallotMeasureContest`` that represents a contest where a candidate is retained in a position, e.g. a judicial retention or recall election.
+
+id
+    Open Civic Data-style id in the format ``ocd-retentioncontest/{{uuid}}``.
+
+candidacy_id
+    Reference to the OCD ``Candidacy`` of the person who will either retain or lose a ``Post`` as a result of the contest.
+
+post_id
+    Reference to the OCD ``Post`` representing the public office the candidate will either retain or lose as a result of the contest.
+
+
+Candidacy
+---------
+
+Represents a person who is a candidate in a particular ``CandidateContest``. If a candidate is running in multiple contests, each contest must have its own ``Candidate`` object. ``Candidate`` objects may not be reused between contests.
+
+id
+    Open Civic Data-style id in the format ``ocd-candidacy/{{uuid}}``.
+
+ballot_name
+    The candidate's name as it will be displayed on the official ballot, e.g. "Ken T. Cuccinelli II" (string).
+
+person_id
+    Reference to an OCD ``Person`` who is the candidate.
+
+post_id
+    References the ``Post`` that represents the public office for which the candidate is competing.
+
+committee_id
+    **optional**
+    Reference to the OCD ``Committee`` (see OCDEP: Campaign Finance Filings) that represents the candidate's campaign committee for the contest.
+
+filed_date
+    **optional**
+    Specifics when the candidate filed for the contest (date).
+
+is_incumbent
+    **optional**
+    Indicates whether the candidate is the incumbent for the office associated with the contest.
+
+is_top_ticket
+    **optional**
+    Indicates that the candidate is the top of a ticket that includes multiple candidates (boolean). For example, the candidate running for President is consider the top of the President/Vice President ticket. In many states, this is also true of the Governor/Lieutenant Governor.
+
+party_id
+    **optional**
+    Reference to and OCD ``Party`` with which the candidate is affiliated.
+
+created_at
+    Specifies when this object was created in the system (datetime).
+
+updated_at
+    Specifies when this object was last updated in the system (datetime).
+
+sources
+    **optional**
+    **repeated**
+    List of sources used in assembling this object. Has the following properties:
+
+    url
+        URL of the resource.
+    note
+        **optional**
+        Description of what this source was used for.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+Party
+-----
+
+Political party with which candidates may be affiliated.
+
+id
+    Open Civic Data-style id in the format ``ocd-party/{{uuid}}``.
+
+name
+    The name of the party (string).
+
+abbreviation
+    **optional**
+    An abbreviation for the party name (string).
+
+color
+    **optional**
+    Six-character hex code representing an HTML color string. The pattern is ``[0-9a-f]{6}``.
+
+is_write_in
+    **optional**
+    Indicates that the party is not officially recognized by a local, state, or federal organization but, rather, is a "write-in" in jurisdictions which allow candidates to free-form enter their political affiliation (boolean).
+
+created_at
+    Time that this object was created at in the system.
+
+updated_at
+    Time that this object was last updated in the system.
+
+sources
+    **optional**
+    **repeated**
+    List of sources used in assembling this object. Has the following properties:
+
+    url
+        URL of the resource.
+    note
+        **optional**
+        Description of what this source was used for.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+BallotSelectionBase
+-------------------
+
+A base class with the properties shared by all ballot selection types: ``BallotMeasureSelection``, ``CandidateSelection`` and ``PartySelection``.
+
+id
+    Open Civic Data-style id in the format ``ocd-ballotselection/{{uuid}}``.
+
+contest_id
+    References the ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` or ``RetentionContest`` in which the ballot selection is an option.
+
+created_at
+    Time that this object was created at in the system.
+
+updated_at
+    Time that this object was last updated in the system.
+
+sources
+    **optional**
+    **repeated**
+    List of sources used in assembling this object. Has the following properties:
+
+    url
+        URL of the resource.
+    note
+        **optional**
+        Description of what this source was used for.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+BallotMeasureSelection
+----------------------
+
+A subclass of ``BallotSelectionBase`` representing a ballot option that a voter could select in a ballot measure contest.
+
+id
+    Open Civic Data-style id in the format ``ocd-ballotmeasureselection/{{uuid}}``.
+
+selection
+    Selection text for the option on the ballot , e.g., "Yes", "No", "Recall", "Don't recall" (string).
+
+
+CandidateSelection
+------------------
+
+A subclass of ``BallotSelectionBase`` representing an option on the ballot that a voter could select in a candidate contest, e.g., a particular candidate or "ticket".
+
+id
+    Open Civic Data-style id in the format ``ocd-candidateselection/{{uuid}}``.
+
+candidates
+    **repeated**
+    Lists each ``Candidate`` associated with the ballot selection. The number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor". Has the following properties:
+
+        candidate_id
+            References the ``Candidate``.
+
+        post_id
+            References the ``Post`` that represents the public office for which the candidate is competing.
+
+endorsement_party_ids
+    **optional**
+    **repeated**
+    Lists each ``Party`` that endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
+
+is_write_in
+    **optional**
+    Indicates that the particular ballot selection allows for write-in candidates. If true, one or more write-in candidates are allowed for this contest (boolean).
+
+
+PartySelection
+--------------
+
+A subclass of ``BallotSelectionBase`` representing an option on the ballot that a voter could select in a party contest.
+
+id
+    Open Civic Data-style id in the format ``ocd-partyselection/{{uuid}}``.
+
+party_ids
+    **repeated**
+    Lists each ``Party`` associated with the ballot selection.
+
+
+Differences with VIP
+====================
+
+Each of the data types described in this proposal corresponds to an element described in the VIP's current `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_. While interoperability with VIP data is a goal of this proposal, there is not a one-to-one mapping between the tags within a VIP element and the properties of its corresponding data type in this OCDEP.
+
+First, a few general differences.
+
+Our use cases require a model of public offices that persist from one election to the next. Thus, in place of VIP's `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, this proposal describes reuse of OCD ``Post`` and ``Organization`` data types.
+
+Similarly, this proposal swaps in OCD's ``Division`` type in place of the `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ and ``<GpUnit>`` (i.e., "Geo-political Unit") elements defined in the VIP and NIST specifications.
+
+VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``pro_statement`` and ``con_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
+
+VIP describes an `<ExternalIdentifier> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/external_identifiers.html>`_ element, which allows connecting VIP data to external data sets. In place of this element, this proposal includes repeating ``indentifiers`` properties on data types that users may want to link to external data sets.
+
+The detailed differences between VIP elements and their corresponding data type in this OCDEP are described below.
+
+Election
+--------
+
+Corresponds to VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<Name>`` is not required on VIP, but ``name`` is required on OCD's ``Event``.
+    - ``<Date>`` is a typed as ``xs:date`` in VIP, but ``start_time`` is a datetime on OCD's ``Event``.
+
+* OCD fields not implemented in VIP:
+
+    - required:
+
+        + ``classification`` inherited from ``Event`` and should always be "election".
+        + ``timezone`` inherited from ``Event`` and should always be local to the state where the election occurs.
+
+    - optional:
+
+        + ``administrative_org_id``
+        + ``description`` inherited from ``Event``
+        + ``location`` inherited from ``Event``
+        + ``all_day`` inherited from ``Event``
+        + ``end_time`` inherited from ``Event``
+        + ``status`` inherited from ``Event``
+        + ``links`` inherited from ``Event``
+        + ``participants`` inherited from ``Event``
+        + ``documents`` inherited from ``Event``
+        + ``media`` inherited from ``Event``
+
+* VIP fields not implemented in this OCDEP:
+
+    - ``<ElectionType>``, which is an optional string that conflates the level of government to which a candidate might be elected (e.g., "federal", "state", "county", etc.) with the point when the election occurs in the overall cycle (e.g., "general", "primary", "runoff" and "special"). If necessary, this could be stored in ``extras``.
+    - ``<HoursOpenId>``, which is an optional reference to a VIP `<HoursOpen> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/hours_open.html>`_ element that represents when polling locations for the election are generally open. If necessary, this unique id and its associated VIP information could be stored in ``extras``.
+    - ``<RegistrationInfo>``, which is an optional string. If the value is a URL, this could be stored in ``links`` or otherwise in ``extras``, if necessary.
+    - ``<RegistrationDeadline>`, which is an optional date that could be stored in ``extras``, if necessary.
+    - ``<HasElectionDayRegistration>``, which is an optional boolean that, if necessary, could be stored in ``extras``, if necessary.
+    - ``<AbsenteeBallotInfo>``, which is an optional string. If the value is a URL, this could be stored in ``links`` or otherwise in ``extras``, if necessary.
+    - ``<AbsenteeRequestDeadline>``, which is an optional date that, if necessary, could be stored in ``extras``, if necessary.
+    - ``<ResultsUri>``, which is optional and could be stored in ``links`` or otherwise in ``extras``, if necessary.
+
+
+ContestBase
+-----------
+
+Corresponds to VIP's `<ContestBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/contest_base.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<ElectoralDistrictId>``, which is an optional reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, is replaced by ``division_id``, which is a required reference to an OCD ``Division``. If necessary, VIP's ``<CandidateId>`` could be stored in ``extras``.
+
+* OCD fields not implemented in VIP:
+
+    - ``election_id`` is a required reference to an OCD ``Election``.
+
+* VIP fields not implemented in this OCDEP:
+
+    - ``Abbreviation``, which is an optional string that could be stored in ``extras``, if necessary.
+    - ``<BallotSelectionIds>``, which is an optional single element that contains a set of references to ballot selections for the contest. Instead, ``BallotSelectionBase`` includes a single, required ``contest_id``.
+    - ``<ElectorateSpecification>``, which an optional string that could be stored in ``extras``, if necessary.
+    - ``<HasRotation>``, which is an optional boolean that could be stored in ``extras``, if necessary.
+    - ``<BallotSubTitle>``,  which is an optional string that could be stored in ``extras``, if necessary.
+    - ``<BallotTitle>``,  which is an optional string that could be stored in ``extras``, if necessary.
+    - ``<SequenceOrder>``,  which is an optional integer that could be stored in ``extras``, if necessary.
+    - ``<VoteVariation>``,  which is an optional reference to a VIP `<VoteVariation> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/vote_variation.html>`_ that could be stored in ``extras``, if necessary.
+    - ``<OtherVoteVariation>``, which is an optional string that could be stored in ``extras``, if necessary.
+
+
+BallotMeasureContest
+--------------------
+
+Corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element.
+
+* No important differences between corresponding fields.
+* No other OCD fields not implemented in VIP.
+* VIP fields not implemented in this OCDEP:
+    
+    - ``<InfoUri>``, which is optional and could be stored in in ``extras``, if necessary.
+
+
+CandidateContest
+----------------
+
+Corresponds to VIP's `<CandidateContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_contest.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, is replaced by ``post_ids``, which is a repeating field that requires at least one reference to an OCD ``Post``. If necessary, VIP's ``<OfficeIds>`` could be stored in ``extras``.
+
+* OCD fields not implemented in VIP:
+
+    - required:
+
+        + ``is_runoff`` could be determined by the ``<ElectionType>`` or inferred from the date of the election.
+        + ``is_unexpired_term`` could be determined by the ``<Name>`` or ``<ElectionType>`` (i.e., if either include the substring "special") or inferred from the date of the election.
+
+    - optional:
+
+        + ``filing_deadline`` is stored in the `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element in VIP.
+
+* VIP fields not implemented in this OCDEP:
+
+    - ``<VotesAllowed>``, which is an optional integer that could be stored in ``extras``, if necessary.
+
+
+PartyContest
+------------
+
+Corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element.
+
+* No important differences between corresponding fields.
+* No other OCD fields not implemented in VIP.
+* No other VIP fields not implemented in this OCDEP.
+
+
+RetentionContest
+----------------
+
+Corresponds to VIP's `<RetentionContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/retention_contest.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, is replaced by ``candidacy_id``, which is a required reference to an OCD ``Candidacy``. If necessary, VIP's ``<CandidateId>`` could be stored in ``extras``.
+    - ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_, is replaced by ``post_id``, which is a required reference to an OCD ``Post``. If necessary, VIP's ``<OfficeId>`` could be stored in ``extras``.
+
+* No other OCD fields not implemented in VIP.
+* No other VIP fields not implemented in this OCDEP.
+
+
+Candidacy
+---------
+
+Corresponds to VIP's `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``party_id`` is an optional reference an OCD ``Party``, not a VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element. If necessary, VIP's ``<PartyId>`` could be stored in ``extras``.
+    - ``person_id`` is a required reference an OCD ``Person``, not a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_ element. If necessary, VIP's ``<PersonId>`` could be stored in ``extras``.
+
+* OCD fields not implemented in VIP:
+
+    - required:
+      
+        + ``post_id`` is required to link the candidate to the public office for which they are competing. In VIP, this is represented as an `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, which is stored on the ``<CandidateContest>`` element.
+
+    - optional:
+      
+        + ``committee_id``
+
+* VIP fields not implemented in this OCDEP:
+
+    - ``<ContactInformation>`` refers to an element that describes the contact of physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be found on the associated ``Person`` or ``Committee`` object.
+    - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_ that could be stored in ``extras``, if necessary.
+    - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_ that could be stored in ``extras``, if necessary.
+
+
+Party
+-----
+
+Corresponds to VIP's `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``name`` is required.
+
+* No other OCD fields not implemented in VIP.
+* VIP fields not implemented in this OCDEP:
+  
+    - ``logo_uri``, which is optional and could be stored in in ``extras``, if necessary.
+
+
+BallotSelectionBase
+-------------------
+
+Corresponds to VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_ element.
+
+* No important differences between corresponding fields.
+* OCD fields not implemented in VIP:
+
+    - ``contest_id`` is required in order to link the selection to its associated contest. In VIP, this link is stored in `<OrderedContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ordered_contest.html>`_, which allows for modeling ballot layouts that vary between electoral districts, but is outside the scope of this proposal.
+
+* Other VIP fields not implemented in this OCDEP:
+
+    - ``<SequenceOrder>``, which is an optional integer that could be stored in in ``extras``, if necessary.
+
+
+BallotMeasureSelection
+----------------------
+
+Corresponds to VIP's `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element.
+
+* No important differences between corresponding fields.
+* No other OCD fields not implemented in VIP.
+* No other VIP fields not implemented in this OCDEP.
+
+
+CandidateSelection
+------------------
+
+Corresponds to VIP's `<CandidateSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_selection.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<CandidateIds>``, which is an optional set of references to VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ elements, is replaced by ``candidates``, which is a repeating field that requires at least one reference to an OCD ``Candidacy``. If necessary, VIP's ``<CandidateIds>`` could be stored in ``extras``.
+    - ``<EndorsementPartyIds>``, which is an optional set of references to VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ elements, is replaced by ``endorsement_party_ids``, which is an optional repeating field that list references to each OCD ``Party`` endorsing the candidate(s). If necessary, VIP's ``<EndorsementPartyIds>`` could be stored in ``extras``.
+
+* No other OCD fields not implemented in VIP.
+* No other VIP fields not implemented in this OCDEP.
+
+
+PartySelection
+--------------
+
+Corresponds to VIP's `<PartySelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_selection.html>`_ element.
+
+* Important differences between corresponding fields:
+
+    - ``<PartyIds>``, which is an optional, set of references to VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ elements, is replaced by ``endorsement_party_ids``, which is an optional repeating field that list references to each OCD ``Party`` associated with the selection. If necessary, VIP's ``<PartyIds>`` could be stored in ``extras``.
+
+* No other OCD fields not implemented in VIP.
+* No other VIP fields not implemented in this OCDEP.
+
+
+Copyright
+=========
+
+This document has been placed in the public domain per the `Creative Commons CC0 1.0 Universal license <http://creativecommons.org/publicdomain/zero/1.0/deed>`_.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -29,7 +29,7 @@ The proposed data types are:
     - ``CandidateSelection``
     - ``PartySelection``
 
-Supplements the "Campaign Finance Filings" proposal being prepared by Abraham Epton.
+Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton.
 
 Rationale
 =========
@@ -41,7 +41,7 @@ Elections are a primary focal point of civic activity in which eligible voters c
 
 Modeling the potential outcomes of these contests is a service to voters who may cast their ballots in an impending election. Modeling the contests' actual outcomes legitimizes the election's results and enables historical electoral analysis.
 
-This proposal is submitted in response to on-going discussion around a related OCDEP focused on campaign-finance disclosures. Representing elections and their contests is necessary for modeling these disclosures because they reveal money raised and spent in support or opposition to specific candidates and ballot measures. However, since notions of elections and their contests run up against other domains, we've separated the definition of these types.
+This proposal is submitted in response to on-going discussion around a related OCDEP focused on campaign finance disclosures. Representing elections and their contests is necessary for modeling these disclosures because they reveal money raised and spent in support or opposition to specific candidates and ballot measures. However, since notions of elections and their contests run up against other domains, we've separated the definition of these types.
 
 The goal of this proposal is to cover the use cases related to the campaign finance domain while laying the foundation for models that will include election results (to be covered in a future OCDEP).
 
@@ -54,9 +54,9 @@ Important differences between this proposal and the current VIP specification ar
 Questions
 =========
 
-* Does ``Election`` need a property to label the election as "general", "primary", "special" or "runoff"? This will likely be somewhere in the name (e.g., "2016") anyway, and these labels don't feel mutually exclusive (e.g., aren't there special primary elections?) VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element has an `ElectionType` field, but this is just a string that you can apparently populate with whatever.
-* Does ``Election`` need a property (maybe ``division_id``) to describe how broad is the broadest geography/jurisdiction of contests? This might be more accurate/flexible than ``Election.is_statewide``.
-* Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But would expect most users typically to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
+* Does ``Election`` need a property to label the election as "general", "primary", "special" or "runoff"? This will likely be somewhere in the name (e.g., "2016 General") anyway, and these labels don't feel mutually exclusive (e.g., aren't there special primary elections?) VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element has an ``ElectionType`` field, but this is just a string that you can apparently populate with whatever.
+* Does ``Election`` need a property (maybe ``division_id``) to describe how broad is the broadest geography/jurisdiction of contests? This might be more accurate/flexible than ``Election.is_statewide``. This point might be more relevant to discuss later in the supplement proposal regarding election results.
+* Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But most users will to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
 * Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
 
 
@@ -96,7 +96,7 @@ Sample Election
 .. code:: javascript
 
     {
-        "id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "id": ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "name": "2016 GENERAL",
         "description": "",
         "start_time": "2016-11-08T00:00:00Z",
@@ -106,22 +106,28 @@ Sample Election
         "classification": "election",
         "created_at": "2017-02-07T07:17:58.874Z",
         "updated_at": "2017-02-07T07:17:58.874Z",
-        "sources": [],
-        "extras": {},
-        "administrative_org_id": "ocd-organization/5b3c95bc-c8fe-4faf-b66d-f9d3175a549c",
-        "identifiers": [
+        "sources": [
             {
-                "scheme": "PropositionScrapedElection.id",
-                "identifier": "17"
+                "note": "Last scraped on 2017-02-08",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Candidates/list.aspx?view=certified&electNav=65"
             },
             {
-                "scheme": "calaccess_id",
+                "note": "Last scraped on 2017-02-07",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Measures/list.aspx?session=2015"
+            }
+        ],
+        "extras": {},
+        "administrative_org_id": "ocd-organization/436b4d67-b5aa-402c-9e20-0e56a8432c80",
+        "identifiers": [
+            {
+                "scheme": "calaccess_election_id",
                 "identifier": "65"
             }
         ],
         "state": "st06",
-        "is_statewide": true,
+        "is_statewide": true
     }
+
 
 ContestBase
 -----------
@@ -173,16 +179,22 @@ Sample ContestBase
 .. code:: javascript
 
     {
-        "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274"
+        "id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c"
         "identifiers": [],
         "name": "STATE SENATE 01",
         "division_id": "ocd-division/country:us/state:ca/sldu:1",
-        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:18:05.438Z",
         "updated_at": "2017-02-07T07:18:05.442Z",
-        "sources": [],
-        "extras": {},
+        "sources": [
+            {
+                "note": "Last scraped on 2017-02-08",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Candidates/list.aspx?view=certified&electNav=65"
+            }
+        ],
+        "extras": {}
     }
+
 
 BallotMeasureContest
 --------------------
@@ -234,28 +246,33 @@ Sample BallotMeasureContest
 .. code:: javascript
 
     {
-        "id": "ocd-contest/8ae42b8b-4996-4134-af67-88cb8869c884",
+        "id": "ocd-contest/2ce7e19b-3feb-4318-9908-eb3fdf456fb0",
         "identifiers": [
             {
-                "scheme": "ScrapedProposition.scraped_id",
+                "scheme": "calaccess_measure_id",
                 "identifier": "1376195"
             }
         ],
         "name": "PROPOSITION 060- ADULT FILMS. CONDOMS. HEALTH REQUIREMENTS. INITIATIVE STATUTE."
         "division_id": "ocd-division/country:us/state:ca",
-        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:17:59.818Z",
         "updated_at": "2017-02-07T07:17:59.818Z",
-        "sources": [],
+        "sources": [
+            {
+                "note": "Last scraped on 2017-02-07",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Measures/Detail.aspx?id=1376195&session=2015"
+            }
+        ],
         "extras": {},
         "con_statement": "",
         "effect_of_abstain": "",
         "full_text": "",
-        "passage_threshold": "",
+        "passage_threshold": "50% plus one vote",
         "pro_statement": "",
-        "summary_text": "",
+        "summary_text": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
         "ballot_measure_type": "initiative",
-        "other_type": "",
+        "other_type": ""
     }
 
 
@@ -295,30 +312,32 @@ Sample CandidateContest
 .. code:: javascript
 
     {
-        "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274",
+        "id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
         "identifiers": [],
         "name": "STATE SENATE 01",
         "division_id": "ocd-division/country:us/state:ca/sldu:1",
-        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:18:05.438Z",
         "updated_at": "2017-02-07T07:18:05.442Z",
-        "sources": [],
+        "sources": [
+            {
+                "note": "Last scraped on 2017-02-08",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Candidates/list.aspx?view=certified&electNav=65"
+            }
+        ],
         "extras": {},
-        "filing_deadline": null,
+        "filing_deadline": 2016-06-07,
         "is_unexpired_term": false,
-        "number_elected": "",
+        "number_elected": 1,
         "party_id": null,
-        "runoff_for_contest_id": null,
+        "runoff_for_contest_id": null
     }
 
 
 PartyContest
 ------------
 
-A subclass of ``ContestBase`` which describes a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States).
-
-id
-    Open Civic Data-style id in the format ``ocd-partycontest/{{uuid}}``.
+A subclass of ``ContestBase`` which represents a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States).
 
 
 RetentionContest
@@ -337,29 +356,34 @@ Sample RetentionContest
 .. code:: javascript
 
     {
-        "id": "ocd-contest/320d0dc1-9fed-4b77-82e9-a2517dc9f0be",
+        "id": "ocd-contest/d0455060-44ee-4fbf-bc7e-7db86084a11e",
         "identifiers": [
             {
-                "scheme": "ScrapedProposition.scraped_id",
+                "scheme": "calaccess_measure_id",
                 "identifier": "1256382"
             }
         ],
         "name": "2003 RECALL QUESTION",
         "division_id": "ocd-division/country:us/state:ca",
-        "election_id": "ocd-event/c2c4af12-6cb0-43d7-bd67-707abbd564d1"
+        "election_id": "ocd-event/3f904160-d304-4753-a542-578cfcb86e76",
         "created_at": "2017-02-07T07:18:00.555Z",
         "updated_at": "2017-02-07T07:18:00.555Z",
-        "sources": [],
+        "sources": [
+            {
+                "note": "Last scraped on 2017-02-07",
+                "url": "http://cal-access.ss.ca.gov/Campaign/Measures/Detail.aspx?id=1256382&session=2003"
+            }
+        ],
         "extras": {},
         "con_statement": "",
         "effect_of_abstain": "",
         "passage_threshold": "",
         "pro_statement": "",
-        "summary_text": "",
+        "summary_text": "SHALL GRAY DAVIS BE RECALLED (REMOVED) FROM THE OFFICE OF GOVERNOR?",
         "full_text": "",
         "ballot_measure_type": "initiative",
         "other_type": "",
-        "membership_id": "ocd-membership/339e7268-1c66-45d9-a5d9-616a8e59ddcf",
+        "membership_id": "ocd-membership/181a0826-f458-403f-ae65-e1ce97b8dd34"
     }
 
 
@@ -428,19 +452,20 @@ Sample Candidacy
 .. code:: javascript
 
     {
-        "id": "ocd-candidacy/a8bb61ad-5551-470d-a8a0-e24e78d729fe",
+        "id": "ocd-candidacy/054f0a6e-9c06-4611-8c2c-3e143843c9d8",
         "ballot_name": "ROWEN, ROBERT J.",
-        "person_id": "ocd-person/1d69c353-75e0-4572-bc1b-c401833e0dae",
-        "post_id": "ocd-post/5dd43b84-a5c2-46a9-8d07-aa82db483e42",
+        "person_id": "ocd-person/edfafa56-686d-49ea-80e5-64bc795493f8",
+        "post_id": "ocd-post/0f169eea-0ad6-48c2-8bc5-ca86e08643d0",
         "committee_id": null,
-        "filed_date": null,
-        "is_incumbent": null,
-        "is_top_ticket": false
-        "created_at": "2017-02-07T07:18:05.473Z",
-        "updated_at": "2017-02-07T07:18:05.473Z",
+        "filed_date": 2016-03-10,
+        "ballot_selection_id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f",
+        "is_incumbent": false,
+        "is_top_ticket": false,
+        "party_id": 'ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1',
+        "created_at": "2017-02-08T04:17:30.818Z",
+        "updated_at": "2017-02-08T04:17:30.818Z",
         "sources": [],
-        "extras": {},
-        "party_id": null,
+        "extras": {}
     }
 
 
@@ -498,12 +523,12 @@ Sample Party
         "id": "ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
         "name": "DEMOCRATIC",
         "abbreviation": "D",
-        "color": "",
-        "is_write_in": null,
+        "color": "1d0ee9",
+        "is_write_in": false,
         "created_at": "2017-02-07T16:36:12.497Z",
         "updated_at": "2017-02-07T16:36:12.497Z",
         "sources": [],
-        "extras": {},
+        "extras": {}
     }
 
 
@@ -515,28 +540,28 @@ A base class with the properties shared by all ballot selection types: ``BallotM
 id
     Open Civic Data-style id in the format ``ocd-ballotselection/{{uuid}}``.
 
-contest_id
-    References the ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` or ``RetentionContest`` in which the ballot selection is an option.
-
 created_at
     Time that this object was created at in the system.
 
 updated_at
     Time that this object was last updated in the system.
 
-sources
-    **optional**
-    **repeated**
-    List of sources used in assembling this object. Has the following properties:
-
-    url
-        URL of the resource.
-    note
-        **optional**
-        Description of what this source was used for.
-
 extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+Sample BallotSelectionBase
+++++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f"
+        "created_at": "2017-02-08T04:17:30.817Z",
+        "updated_at": "2017-02-08T04:17:30.817Z",
+        "extras": {}
+    }
 
 
 BallotMeasureSelection
@@ -550,6 +575,25 @@ id
 selection
     Selection text for the option on the ballot, e.g., "Yes", "No", "Recall", "Don't recall" (string).
 
+contest_id
+    References the ``BallotMeasureContest`` in which the ballot selection is an option.
+
+
+Sample BallotMeasureSelection
++++++++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-ballotselection/85399ed5-b91d-4a7c-a868-dd152ce28ed4",
+        "contest_id": "ocd-contest/2ce7e19b-3feb-4318-9908-eb3fdf456fb0",
+        "selection": "Yes",
+        "created_at": "2017-02-08T04:17:24.486Z",
+        "updated_at": "2017-02-08T04:17:24.486Z",
+        "extras": {}
+    }
+
 
 CandidateSelection
 ------------------
@@ -558,6 +602,9 @@ A subclass of ``BallotSelectionBase`` representing an option on the ballot that 
 
 id
     Open Civic Data-style id in the format ``ocd-candidateselection/{{uuid}}``.
+
+contest_id
+    References the ``CandidateContest`` in which the ballot selection is an option.
 
 candidacy_ids
     **repeated**
@@ -571,6 +618,25 @@ endorsement_party_ids
 is_write_in
     **optional**
     Indicates that the particular ballot selection allows for write-in candidates. If true, one or more write-in candidates are allowed for this contest (boolean).
+
+
+Sample CandidateSelection
++++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f"
+        "contest_id": "ocd-contest/eff6e5bd-10dc-4930-91a0-06e2298ca15c",
+        "candidacy_ids": [
+            "ocd-candidacy/054f0a6e-9c06-4611-8c2c-3e143843c9d8"
+        ],
+        "is_write_in": false,
+        "created_at": "2017-02-08T04:17:30.817Z",
+        "updated_at": "2017-02-08T04:17:30.817Z",
+        "extras": {},
+    }
 
 
 PartySelection

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -47,14 +47,17 @@ Ballot Measure
 Candidacy
     The condition of a person being a candidate. A single person may have multiple candidacies if:
 
-    * The person competed to hold the same public office in more than one election, including a primary election followed by a general election.
     * The person competed to hold multiple public offices, even in the same election.
+    * The person competed to hold the same public office in more than one election. This includes:
+
+        - A person who is elected to a public office, serves a full term and runs for re-election as an incumbent candidate.
+        - A person who wins a contest to become a nominee for a public office (known as a "primary election" in U.S. politics) who goes on to face who advances the final contest of candidates (e.g., the "general election" in U.S. politics).
 
 Candidate
     A person competing to be elected to hold particular public office.
 
 Contest
-    A specific decision with a set of mostly pre-defined options (aka, selections) put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
+    A specific decision with a set of predetermined options (aka, "selections") put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
 
 Election
     A collection of political contests decided in parallel through a process of compiling official ballots cast by voters and adding up the total votes for each selection in each contest.
@@ -75,7 +78,7 @@ Runoff Contest
     A contest conducted to decide a previous contest in which no single selection received the number of votes required to decide the election.
 
 Selection
-    An option available to a voter in an election contest.
+    A predetermined option that voters could select on a ballot in an election contest.
 
 Term of Office
     The period of time a person elected to a public office is expected to hold the public office before being re-elected or replaced.
@@ -83,10 +86,10 @@ Term of Office
     For a variety of reasons, a public office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
 
 Ticket
-    A collection of allied candidates competing together in the same contest in which multiple public offices are decided. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
+    Two or more allied candidates competing together in the same contest in which multiple public offices are decided. For example, in U.S. politics, candidates for President and Vice President run together on the same ticket, with the President at the top of the ticket.
 
 Vote
-    A specific selection selected by a voter by a voter in an election contest.
+    A specific selection selected by a voter on a ballot in an election contest.
 
 Voter
     A person who is eligible to vote in an election.
@@ -118,15 +121,13 @@ Differences from VIP
 
 Each of the data types described in this proposal corresponds to an element described in the VIP's current `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_. While interoperability with VIP data is a goal of this proposal, there is not a one-to-one mapping between the tags within a VIP element and the properties of its corresponding data type in this OCDEP.
 
-Important differences between the proposed OCD data type and its corresponding VIP element are noted, if any, in Implementation_.
+Important differences between the proposed OCD data type and its corresponding VIP element are noted, if any, in each data type's "Mapping to VIP" subsection in Implementation_.
 
 One general note: VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``pro_statement`` and ``con_statement`` of a ``BallotMeasureContest``. In this proposal, these data types are described as simple strings.
 
 Questions
 =========
 
-* Does ``Election`` need a property to label the election as "general", "primary", "special" or "runoff"? This will likely be somewhere in the name (e.g., "2016 General") anyway, and these labels don't feel mutually exclusive (e.g., aren't there special primary elections?) VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element has an ``ElectionType`` field, but this is just a string that you can apparently populate with whatever.
-* Does ``Election`` need a property (maybe ``division_id``) to describe how broad is the broadest geography/jurisdiction of contests? This might be more accurate/flexible than ``Election.is_statewide``. This point might be more relevant to discuss later in the supplement proposal regarding election results.
 * Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But most users will to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
 * Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
 * Should competing to hold a public office in both the primary and the general election count as one candidacy or two?
@@ -136,12 +137,12 @@ Implementation
 ==============
 
 Election
---------
+---------
 
 A collection of political contests set to be decided on the same date.
 
 id
-    Open Civic Data-style id in the format ``ocd-contest/{{uuid}}``.
+    Open Civic Data-style id in the format ``ocd-election/{{uuid}}``.
 
 identifiers
     **optional**
@@ -149,15 +150,15 @@ identifiers
     Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
 
 name
-    Common name for the election, which will typically describe approximately when the election occurred and the scope of the contests to be decided, e.g., "2014 Primaries", "2015 Boone County Elections" or "2016 General Elections".
+    Common name for the election, which will typically describe approximately when the election occurred and the scope of the contests to be decided, e.g., "2014 Primaries", "2015 Boone County Elections" or "2016 General Elections" (string).
 
 date
-    Date on which the election is set to be decided (aka, Election Day). Typically this corresponds to the last day when voters can cast a ballot and the first day when the election's results a publicly reported.
+    Date on which the election is set to be decided (aka, Election Day). Typically this corresponds to the last day when voters can cast a ballot and the first day when the election's results a publicly reported (date).
 
     This date should be considered to be in the timezone local to the election's division.
 
 division_id
-    Reference to the OCD ``Division`` that defines the broadest geographical scope of any contest decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
+    Reference to the OCD ``Division`` that defines the broadest geographical scope of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
 
 administrative_organization_id
     **optional**
@@ -218,15 +219,15 @@ Sample Election
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``Election`` corresponds to VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element.
 
 * Important differences between corresponding fields:
 
     - ``<Name>`` is not required on VIP, but ``name`` is required on OCD's ``Event``.
-    - ``<StateId>``, which is a required reference to a VIP `<State> http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html`_ element, roughly corresponds to ``division_id`` which should reference the same state (if ``<IsStatewide>`` is true on the VIP election) or any of its subdivisions.
+    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, roughly corresponds to ``division_id`` which should reference the same state (if ``<IsStatewide>`` is true on the VIP election) or any of its subdivisions.
 
 * OCD fields not implemented in VIP:
 
@@ -248,7 +249,7 @@ Differences from VIP
 Contest
 -------
 
-A base class with the properties shared by all contest types: ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` and ``RetentionContest``.
+A base class representing a specific decision set before voters in an election. Includes properties shared by all contest types: ``BallotMeasureContest``, ``CandidateContest``, ``PartyContest`` and ``RetentionContest``.
 
 id
     Open Civic Data-style id in the format ``ocd-contest/{{uuid}}``.
@@ -312,8 +313,8 @@ Sample Contest
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``Contest`` corresponds to VIP's `<ContestBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/contest_base.html>`_ element.
 
@@ -341,44 +342,35 @@ Differences from VIP
 BallotMeasureContest
 --------------------
 
-A subclass of ``Contest`` for representing a ballot measure before the voters, including summary statements on each side.
+A subclass of ``Contest`` for representing a ballot measure before the voters, including summary statements on each side. Inherits all of the required and optional properties of ``Contest``.
 
 con_statement
     **optional**
-    Specifies a statement in opposition to the ballot measure. It does not necessarily appear on the ballot (string).
+    A statement in opposition to the ballot measure. It does not necessarily appear on the ballot (string).
 
 effect_of_abstain
     **optional**
     Specifies the effect abstaining from voting on the ballot measure, i.e., whether abstaining is considered a vote against it (string).
 
-full_text
+requirement
     **optional**
-    Specifies the full text of the ballot measure as it appears on the ballot (string).
-
-passage_threshold
-    **optional**
-    Specifies the threshold of votes the ballot measure needs in order to pass (string). The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
+    The threshold of votes the ballot measure needs in order to pass (string). The default is a simple majority, i.e., "50% plus one vote". Other common thresholds are "three-fifths" and "two-thirds".
 
 pro_statement
     **optional**
-    Specifies a statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
+    A statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
 
-summary_text
+summary
     **optional**
-    Specifies a short summary of the ballot measure that is on the ballot, below the title, but above the text.
+    Short summary of the ballot measure that is on the ballot, below the title, but above the text.
+
+text
+    **optional**
+    The full text of the ballot measure as it appears on the ballot (string).
 
 classification
     **optional**
-    Enumerated among:
-
-    * ballot-measure: A catch-all for generic types of non-candidate-based contests.
-    * initiative: These are usually citizen-driven measures to be placed on the ballot. These could include both statutory changes and constitutional amendments.
-    * referendum: These could include measures to repeal existing acts of legislation, legislative referrals, and legislatively-referred state constitutional amendments.
-    * other: Anything that does not fall into the above categories.
-
-other_type
-    **optional**
-    Allows for cataloging a new type of ballot measure option, when type is specified as "other" (string).
+    Describes the origin and/or potential outcome of the ballot measure, e.g., "initiative statute", "legislative constitutional amendment" (string).
 
 
 Sample BallotMeasureContest
@@ -409,17 +401,16 @@ Sample BallotMeasureContest
         "extras": {},
         "con_statement": "",
         "effect_of_abstain": "",
-        "full_text": "",
+        "text": "",
         "passage_threshold": "50% plus one vote",
         "pro_statement": "",
-        "summary_text": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
-        "ballot_measure_type": "initiative",
-        "other_type": ""
+        "summary": "Requires adult film performers to use condoms during filming of sexual intercourse. Requires producers to pay for performer vaccinations, testing, and medical examinations. Requires producers to post condom requirement at film sites. Fiscal Impact: Likely reduction of state and local tax revenues of several million dollars annually. Increased state spending that could exceed $1 million annually on regulation, partially offset by new fees",
+        "ballot_measure_type": "initiative statute"
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element.
 
@@ -429,7 +420,7 @@ Differences from VIP
 CandidateContest
 ----------------
 
-A subclass of ``Contest`` for repesenting a contest among candidates competing for election to a public office.
+A subclass of ``Contest`` for repesenting a contest among candidates competing for election to a public office. Inherits all of the required and optional properties of ``Contest``.
 
 filing_deadline
     **optional**
@@ -484,8 +475,8 @@ Sample CandidateContest
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``CandidateContest`` corresponds to VIP's `<CandidateContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_contest.html>`_ element.
 
@@ -497,7 +488,7 @@ Differences from VIP
 
     - required:
 
-        + ``is_unexpired_term`` could be determined by the ``<Name>`` or ``<ElectionType>`` (i.e., if either include the substring "special") or inferred from the date of the election.
+        + ``is_unexpired_term`` could be inferred from ``<Name>`` or ``<ElectionType>`` tags (e.g., for U.S. elections, these tags would likely include "special") or from the date of the election.
 
     - optional:
 
@@ -512,18 +503,18 @@ Differences from VIP
 PartyContest
 ------------
 
-A subclass of ``Contest`` which represents a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States).
+A subclass of ``Contest`` which represents a contest in which the possible ballot selections are all political parties. These could include contests in which straight-party selections are allowed, or party-list contests (although these are more common outside of the United States). Inherits all of the required and optional properties of ``Contest``.
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
-``PartyContest`` corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element. The two have no signicant differences.
+``PartyContest`` corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element. The two have no significant differences.
 
 
 RetentionContest
 ----------------
 
-A subclass of ``BallotMeasureContest`` that represents a contest where a person is retains or loses a public office, e.g. a judicial retention or recall election.
+A subclass of ``BallotMeasureContest`` that represents a contest where a person is retains or loses a public office, e.g. a judicial retention or recall election. Inherits all of the required and optional properties of ``BallotMeasureContest``.
 
 membership_id
     Reference to the OCD ``Membership`` that represents the tenure of a particular person (i.e., OCD ``Person`` object) in a particular public office (i.e., ``Post`` object).
@@ -567,8 +558,8 @@ Sample RetentionContest
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``RetentionContest`` corresponds to VIP's `<RetentionContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/retention_contest.html>`_ element.
 
@@ -608,7 +599,7 @@ filed_date
 
 is_incumbent
     **optional**
-    Indicates whether the candidate is the incumbent for the office associated with the contest.
+    Indicates whether the candidate is the incumbent for the office associated with the contest (boolean).
 
 is_top_ticket
     **optional**
@@ -663,8 +654,8 @@ Sample Candidacy
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``Candidacy`` corresponds to VIP's `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element.
 
@@ -753,8 +744,8 @@ Sample Party
     }
 
 
-Differences from VIP
-+++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``Party`` corresponds to VIP's `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element.
 
@@ -770,7 +761,7 @@ Differences from VIP
 BallotSelection
 ---------------
 
-A base class with the properties shared by all ballot selection types: ``BallotMeasureSelection``, ``CandidateSelection`` and ``PartySelection``.
+A base class representing a predetermined option on a ballot that voters could select in an election contest. Includes the properties shared by all ballot selection types: ``BallotMeasureSelection``, ``CandidateSelection`` and ``PartySelection``.
 
 id
     Open Civic Data-style id in the format ``ocd-ballotselection/{{uuid}}``.
@@ -799,8 +790,8 @@ Sample BallotSelection
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``BallotMeasureSelection`` corresponds to VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_ element.
 
@@ -816,10 +807,7 @@ Differences from VIP
 BallotMeasureSelection
 ----------------------
 
-A subclass of ``BallotSelection`` representing a ballot option that a voter could select in a ballot measure contest.
-
-id
-    Open Civic Data-style id in the format ``ocd-ballotmeasureselection/{{uuid}}``.
+A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a ballot measure contest, e.g., "yes" or "no". Inherits all of the required and optional properties of ``BallotSelection``.
 
 selection
     Selection text for the option on the ballot, e.g., "Yes", "No", "Recall", "Don't recall" (string).
@@ -844,8 +832,8 @@ Sample BallotMeasureSelection
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``BallotMeasureSelection`` corresponds to VIP's `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element. There are no significant differences between the two.
 
@@ -853,7 +841,7 @@ Differences from VIP
 CandidateSelection
 ------------------
 
-A subclass of ``BallotSelection`` representing an option on the ballot that a voter could select in a candidate contest, e.g., a particular candidate or "ticket".
+A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a candidate contest, e.g., a particular candidate or "ticket". Inherits all of the required and optional properties of ``BallotSelection``.
 
 id
     Open Civic Data-style id in the format ``ocd-candidateselection/{{uuid}}``.
@@ -894,8 +882,8 @@ Sample CandidateSelection
     }
 
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``CandidateSelection`` corresponds to VIP's `<CandidateSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_selection.html>`_ element.
 
@@ -908,7 +896,7 @@ Differences from VIP
 PartySelection
 --------------
 
-A subclass of ``BallotSelection`` representing an option on the ballot that a voter could select in a party contest.
+A subclass of ``BallotSelection`` representing an option that voters could select on a ballot in a party contest. Inherits all of the required and optional properties of ``BallotSelection``.
 
 id
     Open Civic Data-style id in the format ``ocd-partyselection/{{uuid}}``.
@@ -917,8 +905,8 @@ party_ids
     **repeated**
     Lists each identifier of an OCD ``Party`` associated with the ballot selection. Requires at least one ``party_id``.
 
-Differences from VIP
-++++++++++++++++++++
+Mapping to VIP
+++++++++++++++
 
 ``PartySelection`` corresponds to VIP's `<PartySelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_selection.html>`_ element.
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -133,21 +133,14 @@ Election
 
 A collection of political contests set to be decided on the same date.
 
-id
-    Open Civic Data-style id in the format ``ocd-election/{{uuid}}``.
+``Election`` is a subclass of OCD's ``Event`` data type, defined in `OCDEP 4: Events <http://opencivicdata.readthedocs.io/en/latest/proposals/0004.html>`_, which was accepted in June 2014. All of core and optional properties of ``Event`` are inherited by ``Election``.    
+ 
+The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
 
 identifiers
     **optional**
     **repeated**
     Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
-
-name
-    Common name for the election. Typically describes roughly when the election occurred and the scope of the contests to be decided, e.g., "2014 Primaries", "2015 Boone County Elections" or "2016 General Elections" (string).
-
-date
-    Date on which the election is set to be decided (aka, Election Day). This tends to be the last day when voters can cast their ballots and the first day when the election's results a publicly reported (date).
-
-    This date is considered to be in the timezone local to the election's division.
 
 division_id
     Reference to the OCD ``Division`` that defines the broadest geographical scope of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
@@ -155,12 +148,6 @@ division_id
 administrative_organization_id
     **optional**
     Reference to the OCD ``Organization`` that administers the election and publishes the official results.
-
-created_at
-    Time that this object was created at in the system.
-
-updated_at
-    Time that this object was last updated in the system.
 
 sources
     **optional**
@@ -173,9 +160,6 @@ sources
         **optional**
         Description of what this source was used for.
 
-extras
-    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
-
 
 Sample Election
 +++++++++++++++
@@ -184,7 +168,7 @@ Sample Election
 .. code:: javascript
 
     {
-        "id": "ocd-election/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "identifiers": [
             {
                 "scheme": "calaccess_election_id",
@@ -192,7 +176,13 @@ Sample Election
             }
         ],
         "name": "2016 GENERAL",
-        "date": "2016-11-08",
+        "description": "",
+        "start_time": "2016-11-08T00:00:00Z",
+        "division_id": 'ocd-division/country:us/state:ca/',
+        "end_time": null,
+        "timezone": "US/Pacific",     
+        "all_day": true,      
+        "classification": "election",
         "division_id": 'ocd-division/country:us/state:ca/'
         "administrative_organization_id": "ocd-organization/436b4d67-b5aa-402c-9e20-0e56a8432c80",
         "created_at": "2017-02-07T07:17:58.874Z",
@@ -224,6 +214,15 @@ Mapping to VIP
 * OCD fields not implemented in VIP:
 
     - ``administrative_organization_id`` is optional.
+    - ``description`` (inherited from ``Event``) is optional.
+    - ``location`` (inherited from ``Event``) is optional.
+    - ``all_day`` (inherited from ``Event``) is optional.
+    - ``end_time`` (inherited from ``Event``) is optional.
+    - ``status`` (inherited from ``Event``) is optional.
+    - ``links`` (inherited from ``Event``) is optional.
+    - ``participants`` (inherited from ``Event``) is optional.
+    - ``documents`` (inherited from ``Event``) is optional.
+    - ``media`` (inherited from ``Event``) is optional.
 
 * VIP fields not implemented in this OCDEP:
 
@@ -292,7 +291,7 @@ Sample Contest
         "identifiers": [],
         "name": "STATE SENATE 01",
         "division_id": "ocd-division/country:us/state:ca/sldu:1",
-        "election_id": "ocd-election/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:18:05.438Z",
         "updated_at": "2017-02-07T07:18:05.442Z",
         "sources": [
@@ -382,7 +381,7 @@ Sample BallotMeasureContest
         ],
         "name": "PROPOSITION 060- ADULT FILMS. CONDOMS. HEALTH REQUIREMENTS. INITIATIVE STATUTE."
         "division_id": "ocd-division/country:us/state:ca",
-        "election_id": "ocd-election/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:17:59.818Z",
         "updated_at": "2017-02-07T07:17:59.818Z",
         "sources": [
@@ -466,7 +465,7 @@ Sample CandidateContest
         "identifiers": [],
         "name": "STATE SENATE 01",
         "division_id": "ocd-division/country:us/state:ca/sldu:1",
-        "election_id": "ocd-election/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "election_id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
         "created_at": "2017-02-07T07:18:05.438Z",
         "updated_at": "2017-02-07T07:18:05.442Z",
         "sources": [
@@ -551,7 +550,7 @@ Sample RetentionContest
         ],
         "name": "2003 RECALL QUESTION",
         "division_id": "ocd-division/country:us/state:ca",
-        "election_id": "ocd-election/3f904160-d304-4753-a542-578cfcb86e76",
+        "election_id": "ocd-event/3f904160-d304-4753-a542-578cfcb86e76",
         "created_at": "2017-02-07T07:18:00.555Z",
         "updated_at": "2017-02-07T07:18:00.555Z",
         "sources": [
@@ -695,7 +694,9 @@ Mapping to VIP
 Party
 -----
 
-A subclass of ``Organization`` (as described in [OCDEP 5](http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html) for representing a political party with which office holders and candidates may be affiliated.
+A political party with which office holders and candidates may be affiliated.
+
+``Party`` is a subclass of OCD's ``Organization`` data type, defined in `OCDEP 5: People, Organizations, Posts, and Memberships <http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html>`_, which was accepted in June 2014. All of core and optional properties of ``Organization`` are inherited by ``Party``.
 
 abbreviation
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -82,7 +82,7 @@ identifiers
 
 administrative_org_id
     **optional**
-    Reference to the ``Organization`` that administers the election.
+    Reference to the OCD ``Organization`` that administers the election.
 
 state
     `FIPS code <https://en.wikipedia.org/wiki/Federal_Information_Processing_Standard_state_code>`_ of the state where the election is being held. Recorded in the format ``st{{fips}}`` to match references to VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_  elements (string).
@@ -109,7 +109,7 @@ name
     Name of the contest, not necessarily as it appears on the ballot (string).
 
 division_id
-    Reference to the ``Division`` that defines the geographical scope of the contest, e.g., a specific Congressional or State Senate district.
+    Reference to the OCD ``Division`` that defines the geographical scope of the contest, e.g., a specific Congressional or State Senate district.
 
 election_id
     Reference to the OCD ``Election`` in which the contest is decided.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -225,7 +225,7 @@ id
 RetentionContest
 ----------------
 
-A subclass of ``BallotMeasureContest`` that represents a contest where a candidate is retained in a position, e.g. a judicial retention or recall election.
+A subclass of ``BallotMeasureContest`` that represents a contest where a person is retains or loses a public office, e.g. a judicial retention or recall election.
 
 id
     Open Civic Data-style id in the format ``ocd-retentioncontest/{{uuid}}``.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -22,7 +22,6 @@ The proposed data types are:
     - ``RetentionContest``
 
 * ``Candidacy``
-* ``OfficeTerm``
 * ``Party``
 
 Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton, and lays the foundation for a future proposal covering election results.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -377,7 +377,7 @@ id
     Open Civic Data-style id in the format ``ocd-ballotmeasureselection/{{uuid}}``.
 
 selection
-    Selection text for the option on the ballot , e.g., "Yes", "No", "Recall", "Don't recall" (string).
+    Selection text for the option on the ballot, e.g., "Yes", "No", "Recall", "Don't recall" (string).
 
 
 CandidateSelection

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -257,7 +257,7 @@ committee_id
 
 filed_date
     **optional**
-    Specifics when the candidate filed for the contest (date).
+    Specifies when the candidate filed for the contest (date).
 
 is_incumbent
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -161,7 +161,7 @@ passage_threshold
 
 pro_statement
     **optional**
-    Specifies a statement in favor of the referendum. It does not necessarily appear on the ballot (string).
+    Specifies a statement in favor of the ballot measure. It does not necessarily appear on the ballot (string).
 
 summary_text
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -656,7 +656,7 @@ Sample Candidacy
         "filed_date": 2016-03-10,
         "ballot_selection_id": "ocd-ballotselection/d2716878-99fa-467b-b3b6-d28862a6802f",
         "is_incumbent": false,
-        "party_id": 'ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1',
+        "party_id": 'ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1',
         "created_at": "2017-02-08T04:17:30.818Z",
         "updated_at": "2017-02-08T04:17:30.818Z",
         "sources": [],
@@ -695,13 +695,7 @@ Mapping to VIP
 Party
 -----
 
-Political organization with which office holders and candidates may be affiliated.
-
-id
-    Open Civic Data-style id in the format ``ocd-party/{{uuid}}``.
-
-name
-    The name of the party (string).
+A subclass of ``Organization`` (as described in [OCDEP 5](http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html) for representing a political party with which office holders and candidates may be affiliated.
 
 abbreviation
     **optional**
@@ -715,26 +709,6 @@ is_write_in
     **optional**
     Indicates that the party is not officially recognized by a local, state, or federal organization but, rather, is a "write-in" in jurisdictions which allow candidates to free-form enter their political affiliation (boolean).
 
-created_at
-    Time that this object was created at in the system.
-
-updated_at
-    Time that this object was last updated in the system.
-
-sources
-    **optional**
-    **repeated**
-    List of sources used in assembling this object. Has the following properties:
-
-    url
-        URL of the resource.
-    note
-        **optional**
-        Description of what this source was used for.
-
-extras
-    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
-
 
 Sample Party
 ++++++++++++
@@ -743,8 +717,20 @@ Sample Party
 .. code:: javascript
 
     {
-        "id": "ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
+        "id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
         "name": "DEMOCRATIC",
+        "image": "",
+        "parent": null,
+        "jurisdiction": null,
+        "classification": "party",
+        "founding_date": "",
+        "dissolution_date": "",
+        "identifiers": [],
+        "other_names": [],
+        "contact_details": [],
+        "links": [],
+        "memberships": [],
+        "posts": [],
         "abbreviation": "D",
         "color": "1d0ee9",
         "is_write_in": false,

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -193,8 +193,9 @@ filing_deadline
     **optional**
     Specifies the date and time when a candidate must have filed for the contest for the office (datetime).
 
-is_runoff
-    Indicates a contest to decide a prior contest that ended with no candidate receiving a majority of the votes (boolean).
+runoff_for_contest_id
+    **optional**
+    If this contest is a runoff to determine the outcome of a previously undecided contest, reference to that ``CandidateContest``.
 
 is_unexpired_term
     Indicates that the former public office holder vacated the post before serving a full term (boolean).

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -54,7 +54,8 @@ Important differences between this proposal and the current VIP specification ar
 Questions
 =========
 
-* Does ``Election`` need one property (or two properties) to store the election type (e.g., general, primary, special) and/or election level (e.g., federal, state, county, local)? VIP's `<Election> <>`_ element has an `ElectionType` field, but this is just a string that you can apparently populate with whatever.
+* Does ``Election`` need a property to label the election as "general", "primary", "special" or "runoff"? This will likely be somewhere in the name (e.g., "2016") anyway, and these labels don't feel mutually exclusive (e.g., aren't there special primary elections?) VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element has an `ElectionType` field, but this is just a string that you can apparently populate with whatever.
+* Does ``Election`` need a property (maybe ``division_id``) to describe how broad is the broadest geography/jurisdiction of contests? This might be more accurate/flexible than ``Election.is_statewide``.
 * Should ``Party`` be implemented as an ``Organization`` (or subclass)? If so, how do we handle national parties versus state parties (e.g., the DNC versus Missouri Democratic Party)? Would probably be more accurate to associate state and local candidates with state parties and federal candidates with the national parties. But would expect most users typically to want all Democrats to be grouped together regardless of the level of government, especially when analyzing election results.
 * Should the proposed subclasses of OCD data types (e.g., ``Election``, ``BallotMeasureContest``,  ``CandidateContest``) each implement its own ID or should it just inherit the id field of the base class?
 

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -638,6 +638,15 @@ filed_date
     **optional**
     Specifies when the candidate filed for the contest (date).
 
+registration_status
+    **optional**
+    Registration of the candidate. Enumerated among:
+
+    - *filed:* The candidate filed for office but is not qualified.
+    - *qualified:* The candidate qualified for the contest.
+    - *withdrawn:* The candidate withdrew from the contest (but may still be on the ballot).
+    - *write-in:* While the candidate's name did not appear on the ballot, he or she nonetheless campaigned for voter to write in his or her name.
+
 is_incumbent
     **optional**
     Indicates whether the candidate is seeking re-election to a public office he/she currently holds (boolean).
@@ -685,6 +694,7 @@ Sample Candidacy
         "candidate_name": "ROWEN, ROBERT J.",
         "filed_date": "2016-03-10",
         "is_incumbent": false,
+        "registration_status": "qualified",
         "party_id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1",
         "top_ticket_candidacy_id": null,
         "created_at": "2017-02-08T04:17:30.818Z",
@@ -703,7 +713,8 @@ Mapping to VIP
   
     - ``<PartyId>``, which is an optional reference a VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element, can map to an equivalent OCD ``Party``.
     - ``person_id`` , which is an optional reference a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_ element, can map to an equivalent OCD ``Person``.
-    - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates, is replaced by an optional ``top_ticket_candidacy_id``. 
+    - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates, is replaced by an optional ``top_ticket_candidacy_id``.
+    - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_ is replaced by an optional ``registration_status``.
 
 * OCD fields not implemented in VIP:
       
@@ -714,7 +725,6 @@ Mapping to VIP
 
     - ``<ContactInformation>`` refers to an element that describes the contact and physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be stored on the associated ``Person`` or ``Committee`` object.
     - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_.
-    - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_.
 
 
 Party

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -294,22 +294,22 @@ Sample CandidateContest
 
 .. code:: javascript
 
-{
-    "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274",
-    "identifiers": [],
-    "name": "STATE SENATE 01",
-    "division_id": "ocd-division/country:us/state:ca/sldu:1",
-    "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
-    "created_at": "2017-02-07T07:18:05.438Z",
-    "updated_at": "2017-02-07T07:18:05.442Z",
-    "sources": [],
-    "extras": {},
-    "filing_deadline": null,
-    "is_unexpired_term": false,
-    "number_elected": "",
-    "party_id": null,
-    "runoff_for_contest_id": null,
-}
+    {
+        "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274",
+        "identifiers": [],
+        "name": "STATE SENATE 01",
+        "division_id": "ocd-division/country:us/state:ca/sldu:1",
+        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "created_at": "2017-02-07T07:18:05.438Z",
+        "updated_at": "2017-02-07T07:18:05.442Z",
+        "sources": [],
+        "extras": {},
+        "filing_deadline": null,
+        "is_unexpired_term": false,
+        "number_elected": "",
+        "party_id": null,
+        "runoff_for_contest_id": null,
+    }
 
 
 PartyContest
@@ -336,31 +336,31 @@ Sample RetentionContest
 
 .. code:: javascript
 
-{
-    "id": "ocd-contest/320d0dc1-9fed-4b77-82e9-a2517dc9f0be",
-    "identifiers": [
-        {
-            "scheme": "ScrapedProposition.scraped_id",
-            "identifier": "1256382"
-        }
-    ],
-    "name": "2003 RECALL QUESTION",
-    "division_id": "ocd-division/country:us/state:ca",
-    "election_id": "ocd-event/c2c4af12-6cb0-43d7-bd67-707abbd564d1"
-    "created_at": "2017-02-07T07:18:00.555Z",
-    "updated_at": "2017-02-07T07:18:00.555Z",
-    "sources": [],
-    "extras": {},
-    "con_statement": "",
-    "effect_of_abstain": "",
-    "passage_threshold": "",
-    "pro_statement": "",
-    "summary_text": "",
-    "full_text": "",
-    "ballot_measure_type": "initiative",
-    "other_type": "",
-    "membership_id": "ocd-membership/339e7268-1c66-45d9-a5d9-616a8e59ddcf",
-}
+    {
+        "id": "ocd-contest/320d0dc1-9fed-4b77-82e9-a2517dc9f0be",
+        "identifiers": [
+            {
+                "scheme": "ScrapedProposition.scraped_id",
+                "identifier": "1256382"
+            }
+        ],
+        "name": "2003 RECALL QUESTION",
+        "division_id": "ocd-division/country:us/state:ca",
+        "election_id": "ocd-event/c2c4af12-6cb0-43d7-bd67-707abbd564d1"
+        "created_at": "2017-02-07T07:18:00.555Z",
+        "updated_at": "2017-02-07T07:18:00.555Z",
+        "sources": [],
+        "extras": {},
+        "con_statement": "",
+        "effect_of_abstain": "",
+        "passage_threshold": "",
+        "pro_statement": "",
+        "summary_text": "",
+        "full_text": "",
+        "ballot_measure_type": "initiative",
+        "other_type": "",
+        "membership_id": "ocd-membership/339e7268-1c66-45d9-a5d9-616a8e59ddcf",
+    }
 
 
 Candidacy
@@ -427,21 +427,21 @@ Sample Candidacy
 
 .. code:: javascript
 
-{
-    "id": "ocd-candidacy/a8bb61ad-5551-470d-a8a0-e24e78d729fe",
-    "ballot_name": "ROWEN, ROBERT J.",
-    "person_id": "ocd-person/1d69c353-75e0-4572-bc1b-c401833e0dae",
-    "post_id": "ocd-post/5dd43b84-a5c2-46a9-8d07-aa82db483e42",
-    "committee_id": null,
-    "filed_date": null,
-    "is_incumbent": null,
-    "is_top_ticket": false
-    "created_at": "2017-02-07T07:18:05.473Z",
-    "updated_at": "2017-02-07T07:18:05.473Z",
-    "sources": [],
-    "extras": {},
-    "party_id": null,
-}
+    {
+        "id": "ocd-candidacy/a8bb61ad-5551-470d-a8a0-e24e78d729fe",
+        "ballot_name": "ROWEN, ROBERT J.",
+        "person_id": "ocd-person/1d69c353-75e0-4572-bc1b-c401833e0dae",
+        "post_id": "ocd-post/5dd43b84-a5c2-46a9-8d07-aa82db483e42",
+        "committee_id": null,
+        "filed_date": null,
+        "is_incumbent": null,
+        "is_top_ticket": false
+        "created_at": "2017-02-07T07:18:05.473Z",
+        "updated_at": "2017-02-07T07:18:05.473Z",
+        "sources": [],
+        "extras": {},
+        "party_id": null,
+    }
 
 
 Party
@@ -494,17 +494,17 @@ Sample Party
 
 .. code:: javascript
 
-{
-    "id": "ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
-    "name": "DEMOCRATIC",
-    "abbreviation": "D",
-    "color": "",
-    "is_write_in": null,
-    "created_at": "2017-02-07T16:36:12.497Z",
-    "updated_at": "2017-02-07T16:36:12.497Z",
-    "sources": [],
-    "extras": {},
-}
+    {
+        "id": "ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
+        "name": "DEMOCRATIC",
+        "abbreviation": "D",
+        "color": "",
+        "is_write_in": null,
+        "created_at": "2017-02-07T16:36:12.497Z",
+        "updated_at": "2017-02-07T16:36:12.497Z",
+        "sources": [],
+        "extras": {},
+    }
 
 
 BallotSelectionBase

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -640,7 +640,7 @@ filed_date
 
 registration_status
     **optional**
-    Registration of the candidate. Enumerated among:
+    Enumerated among:
 
     - *filed:* The candidate filed for office but is not qualified.
     - *qualified:* The candidate qualified for the contest.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -72,9 +72,6 @@ A collection of political contests set to be decided on the same date.
 
 The typical implementation will be an ``all_day`` event witht a "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
 
-id
-    Open Civic Data-style id in the format ``ocd-election/{{uuid}}``.
-
 identifiers
     **optional**
     **repeated**
@@ -91,6 +88,40 @@ is_statewide
     **optional**
     Indicates whether the election is statewide (boolean).
 
+
+Sample Election
++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "name": "2016 GENERAL",
+        "description": "",
+        "start_time": "2016-11-08T00:00:00Z",
+        "end_time": null
+        "timezone": "US/Pacific",
+        "all_day": true,
+        "classification": "election",
+        "created_at": "2017-02-07T07:17:58.874Z",
+        "updated_at": "2017-02-07T07:17:58.874Z",
+        "sources": [],
+        "extras": {},
+        "administrative_org_id": "ocd-organization/5b3c95bc-c8fe-4faf-b66d-f9d3175a549c",
+        "identifiers": [
+            {
+                "scheme": "PropositionScrapedElection.id",
+                "identifier": "17"
+            },
+            {
+                "scheme": "calaccess_id",
+                "identifier": "65"
+            }
+        ],
+        "state": "st06",
+        "is_statewide": true,
+    }
 
 ContestBase
 -----------
@@ -135,13 +166,28 @@ extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
 
 
+Sample ContestBase
++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274"
+        "identifiers": [],
+        "name": "STATE SENATE 01",
+        "division_id": "ocd-division/country:us/state:ca/sldu:1",
+        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "created_at": "2017-02-07T07:18:05.438Z",
+        "updated_at": "2017-02-07T07:18:05.442Z",
+        "sources": [],
+        "extras": {},
+    }
+
 BallotMeasureContest
 --------------------
 
 A subclass of ``ContestBase`` for representing a ballot measure before the voters, including summary statements on each side.
-
-id
-    Open Civic Data-style id in the format ``ocd-ballotmeasurecontest/{{uuid}}``
 
 con_statement
     **optional**
@@ -167,7 +213,7 @@ summary_text
     **optional**
     Specifies a short summary of the ballot measure that is on the ballot, below the title, but above the text.
 
-type
+ballot_measure_type
     **optional**
     Enumerated among:
 
@@ -181,21 +227,46 @@ other_type
     Allows for cataloging a new type of ballot measure option, when type is specified as "other" (string).
 
 
+Sample BallotMeasureContest
++++++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+    {
+        "id": "ocd-contest/8ae42b8b-4996-4134-af67-88cb8869c884",
+        "identifiers": [
+            {
+                "scheme": "ScrapedProposition.scraped_id",
+                "identifier": "1376195"
+            }
+        ],
+        "name": "PROPOSITION 060- ADULT FILMS. CONDOMS. HEALTH REQUIREMENTS. INITIATIVE STATUTE."
+        "division_id": "ocd-division/country:us/state:ca",
+        "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+        "created_at": "2017-02-07T07:17:59.818Z",
+        "updated_at": "2017-02-07T07:17:59.818Z",
+        "sources": [],
+        "extras": {},
+        "con_statement": "",
+        "effect_of_abstain": "",
+        "full_text": "",
+        "passage_threshold": "",
+        "pro_statement": "",
+        "summary_text": "",
+        "ballot_measure_type": "initiative",
+        "other_type": "",
+    }
+
+
 CandidateContest
 ----------------
 
 A subclass of ``ContestBase`` for repesenting a contest among candidates competing for election to a public office.
 
-id
-    Open Civic Data-style id in the format ``ocd-candidatecontest/{{uuid}}``.
-
 filing_deadline
     **optional**
     Specifies the date and time when a candidate must have filed for the contest for the office (datetime).
-
-runoff_for_contest_id
-    **optional**
-    If this contest is a runoff to determine the outcome of a previously undecided contest, reference to that ``CandidateContest``.
 
 is_unexpired_term
     Indicates that the former public office holder vacated the post before serving a full term (boolean).
@@ -212,6 +283,34 @@ party_id
     **optional**
     If the contest is among candidates of the same political party, e.g., a partisan primary election, reference to the OCD ``Party`` representing that political party.
 
+runoff_for_contest_id
+    **optional**
+    If this contest is a runoff to determine the outcome of a previously undecided contest, reference to that ``CandidateContest``.
+
+
+Sample CandidateContest
++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+{
+    "id": "ocd-contest/24e7d3e0-0ac3-4a2d-bbd9-6082e37c6274",
+    "identifiers": [],
+    "name": "STATE SENATE 01",
+    "division_id": "ocd-division/country:us/state:ca/sldu:1",
+    "election_id": "ocd-event/acff908d-7420-4f2c-9688-8103d1736094",
+    "created_at": "2017-02-07T07:18:05.438Z",
+    "updated_at": "2017-02-07T07:18:05.442Z",
+    "sources": [],
+    "extras": {},
+    "filing_deadline": null,
+    "is_unexpired_term": false,
+    "number_elected": "",
+    "party_id": null,
+    "runoff_for_contest_id": null,
+}
+
 
 PartyContest
 ------------
@@ -227,11 +326,41 @@ RetentionContest
 
 A subclass of ``BallotMeasureContest`` that represents a contest where a person is retains or loses a public office, e.g. a judicial retention or recall election.
 
-id
-    Open Civic Data-style id in the format ``ocd-retentioncontest/{{uuid}}``.
-
 membership_id
     Reference to the OCD ``Membership`` that represents the tenure of a particular person (i.e., OCD ``Person`` object) in a particular public office (i.e., ``Post`` object).
+
+
+Sample RetentionContest
++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+{
+    "id": "ocd-contest/320d0dc1-9fed-4b77-82e9-a2517dc9f0be",
+    "identifiers": [
+        {
+            "scheme": "ScrapedProposition.scraped_id",
+            "identifier": "1256382"
+        }
+    ],
+    "name": "2003 RECALL QUESTION",
+    "division_id": "ocd-division/country:us/state:ca",
+    "election_id": "ocd-event/c2c4af12-6cb0-43d7-bd67-707abbd564d1"
+    "created_at": "2017-02-07T07:18:00.555Z",
+    "updated_at": "2017-02-07T07:18:00.555Z",
+    "sources": [],
+    "extras": {},
+    "con_statement": "",
+    "effect_of_abstain": "",
+    "passage_threshold": "",
+    "pro_statement": "",
+    "summary_text": "",
+    "full_text": "",
+    "ballot_measure_type": "initiative",
+    "other_type": "",
+    "membership_id": "ocd-membership/339e7268-1c66-45d9-a5d9-616a8e59ddcf",
+}
 
 
 Candidacy
@@ -292,6 +421,29 @@ extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
 
 
+Sample Candidacy
++++++++++++++++++++++++
+
+
+.. code:: javascript
+
+{
+    "id": "ocd-candidacy/a8bb61ad-5551-470d-a8a0-e24e78d729fe",
+    "ballot_name": "ROWEN, ROBERT J.",
+    "person_id": "ocd-person/1d69c353-75e0-4572-bc1b-c401833e0dae",
+    "post_id": "ocd-post/5dd43b84-a5c2-46a9-8d07-aa82db483e42",
+    "committee_id": null,
+    "filed_date": null,
+    "is_incumbent": null,
+    "is_top_ticket": false
+    "created_at": "2017-02-07T07:18:05.473Z",
+    "updated_at": "2017-02-07T07:18:05.473Z",
+    "sources": [],
+    "extras": {},
+    "party_id": null,
+}
+
+
 Party
 -----
 
@@ -334,6 +486,25 @@ sources
 
 extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
+
+
+Sample Party
+++++++++++++
+
+
+.. code:: javascript
+
+{
+    "id": "ocd-party/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
+    "name": "DEMOCRATIC",
+    "abbreviation": "D",
+    "color": "",
+    "is_write_in": null,
+    "created_at": "2017-02-07T16:36:12.497Z",
+    "updated_at": "2017-02-07T16:36:12.497Z",
+    "sources": [],
+    "extras": {},
+}
 
 
 BallotSelectionBase

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -230,11 +230,8 @@ A subclass of ``BallotMeasureContest`` that represents a contest where a candida
 id
     Open Civic Data-style id in the format ``ocd-retentioncontest/{{uuid}}``.
 
-candidacy_id
-    Reference to the OCD ``Candidacy`` of the person who will either retain or lose a ``Post`` as a result of the contest.
-
-post_id
-    Reference to the OCD ``Post`` representing the public office the candidate will either retain or lose as a result of the contest.
+membership_id
+    Reference to the OCD ``Membership`` that represents the tenure of a particular person (i.e., OCD ``Person`` object) in a particular public office (i.e., ``Post`` object).
 
 
 Candidacy
@@ -391,15 +388,9 @@ A subclass of ``BallotSelectionBase`` representing an option on the ballot that 
 id
     Open Civic Data-style id in the format ``ocd-candidateselection/{{uuid}}``.
 
-candidates
+candidacy_ids
     **repeated**
-    Lists each ``Candidate`` associated with the ballot selection. The number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor". Has the following properties:
-
-        candidate_id
-            References the ``Candidate``.
-
-        post_id
-            References the ``Post`` that represents the public office for which the candidate is competing.
+    Lists each identifier of a ``Candidacy`` associated with the ballot selection. Requires at least one ``candidacy_id``, but the number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor".
 
 endorsement_party_ids
     **optional**
@@ -421,7 +412,7 @@ id
 
 party_ids
     **repeated**
-    Lists each ``Party`` associated with the ballot selection.
+    Lists each ``Party`` associated with the ballot selection. Requires at least one ``party_id``.
 
 
 Differences with VIP
@@ -563,12 +554,12 @@ Corresponds to VIP's `<RetentionContest> <http://vip-specification.readthedocs.i
 
 * Important differences between corresponding fields:
 
-    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, is replaced by ``candidacy_id``, which is a required reference to an OCD ``Candidacy``. If necessary, VIP's ``<CandidateId>`` could be stored in ``extras``.
-    - ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_, is replaced by ``post_id``, which is a required reference to an OCD ``Post``. If necessary, VIP's ``<OfficeId>`` could be stored in ``extras``.
+    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, and ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, are replaced by ``membership_id``, which is a required reference to an OCD ``Membership`` representing a particular person's tenure in a particular public office. If necessary, VIP's ``<CandidateId>`` could be stored in ``extras``.
 
 * No other OCD fields not implemented in VIP.
-* No other VIP fields not implemented in this OCDEP.
+* VIP fields not implemented in this OCDEP:
 
+    - ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_. VIP's ``<Office>`` element corresponds to OCD's ``Post`` data type. In this proposal, a candidate's ``post_id`` is stored on ``Candidacy``, including . If necessary, VIP's ``<OfficeId>`` could be stored in ``extras``.
 
 Candidacy
 ---------

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -206,7 +206,7 @@ number_elected
 
 post_ids
     **repeating**
-    References to the OCD ``Posts`` representing the public offices for which the candidates are competing. If multiple, the primary post should be listed first, e.g., the id for the President post should be listed before the id for Vice-President.
+    Lists each identifier of an OCD ``Post`` representing a public office for which the candidates are competing in the contest. If multiple, the primary post should be listed first, e.g., the id for the President post should be listed before the id for Vice-President.
 
 party_id
     **optional**
@@ -390,12 +390,12 @@ id
 
 candidacy_ids
     **repeated**
-    Lists each identifier of a ``Candidacy`` associated with the ballot selection. Requires at least one ``candidacy_id``, but the number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor".
+    Lists each identifier of an OCD ``Candidacy`` associated with the ballot selection. Requires at least one ``candidacy_id``, but the number of candidates is unbounded in cases where the ballot selection is for a ticket, e.g. "President/Vice President", "Governor/Lt Governor".
 
 endorsement_party_ids
     **optional**
     **repeated**
-    Lists each ``Party`` that is endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
+    Lists each identifer of an OCD ``Party`` that is endorsing the candidates associated with the selection. The number of parties is unbounded in cases where multiple parties endorse a single candidate/ticket.
 
 is_write_in
     **optional**
@@ -412,7 +412,7 @@ id
 
 party_ids
     **repeated**
-    Lists each ``Party`` associated with the ballot selection. Requires at least one ``party_id``.
+    Lists each identifier of an OCD ``Party`` associated with the ballot selection. Requires at least one ``party_id``.
 
 
 Differences with VIP

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -791,15 +791,9 @@ Sample BallotSelection
 Mapping to VIP
 ++++++++++++++
 
-``BallotMeasureSelection`` corresponds to VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_ element.
+``BallotSelection`` corresponds to VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_ element.
 
-* OCD fields not implemented in VIP:
-
-    - ``contest_id`` is required in order to link the selection to its associated contest. In VIP, this link is stored in `<OrderedContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ordered_contest.html>`_, which allows for modeling ballot layouts that vary between electoral districts, but is outside the scope of this proposal.
-
-* Other VIP fields not implemented in this OCDEP:
-
-    - ``<SequenceOrder>``, which is an optional integer.
+VIP includes ``<SequenceOrder>``, which is an optional integer that is not implemented in this proposal.
 
 
 BallotMeasureSelection


### PR DESCRIPTION
Third time's the charm!

My [first PR](https://github.com/datamade/docs.opencivicdata.org/pull/1) was on datamade's fork of this repo. This [second one](https://github.com/opencivicdata/docs.opencivicdata.org/pull/63) was on this repo, but from datamade's fork which included some commits to files I never intended to change (probably as a result of my shoddy attempt to squash the commits).

We've essentially borrowed everything from the [VIP XML spec](http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements) that feels useful for the campaign finance use cases. Differences between proposed OCD data types and VIP elements are noted below.

This proposal doesn't include modeling election results (which also aren't in VIP). Will cover that in a future proposal.

@aepton: Saw your comments on the original PR. I've made a few changes you suggest and will run through each of your comments. After that, if you feel like I haven't  adequetely address your questions/concerns, do you mind moving those comments over to this PR? Sorry for the redundant work! 

@fgregg, @palewire and @dwillis and whoever else: Please give it look!