### PR TITLE
Adding support for positions on ballot measures

### DIFF
--- a/proposals/drafts/campaign_finance_filings.rst
+++ b/proposals/drafts/campaign_finance_filings.rst
@@ -232,12 +232,6 @@ statuses
         "contesting election" - allows for consolidating different
         jurisdictional status schemes into standard types.
 
-designations
-    **optional**
-    **repeated**
-    The Candidate Designations that apply to this Committee - i.e., is it supporting or
-    opposing certain candidates?
-
 contest_positions
     **optional**
     **repeated**
@@ -265,22 +259,6 @@ name
 
 jurisdiction
     An OCD Jurisdiction.
-
-Candidate Designation
----------------------
-
-A Committee may have no relation to any specific Candidate, but if they do have
-such a relationship, the options are complex. Hence this type.
-
-id
-    Open Civic Data-style ID in the format
-    ``ocd-campaign-finance-candidate-designation/{{uuid}}``.
-
-candidate
-    OCD Person indicating the candidate.
-
-designation
-    Enumerated among "primary vehicle for", "surplus account for", "independent expenditure" and other relationship types.
 
 Filing Type
 -----------

--- a/proposals/drafts/campaign_finance_filings.rst
+++ b/proposals/drafts/campaign_finance_filings.rst
@@ -31,6 +31,9 @@ Section
     A container for a unit of meaning inside a Filing, that isn't inherent to
     the basic process of filing a document with an agency.
 
+Contest
+    A specific decision with a set of predetermined options put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
+
 Rationale
 =========
 
@@ -236,6 +239,21 @@ designations
     The Candidate Designations that apply to this Committee - i.e., is it supporting or
     opposing certain candidates?
 
+contest_positions
+    **optional**
+    **repeated**
+    List of the election contests in which the committee has declared a preferred outcome. Has the following properties:
+
+    contest_id
+        Reference to the OCD ``Contest`` in which the committee has declared a position.
+
+    position
+        Enumerated among "supports" and "opposes".
+
+    candidacy_id
+        **optional**
+        If the contest is a ``CandidateContest``, reference to a specific ``Candidacy`` the committee supports or opposes.
+
 Committee Type
 --------------
 
@@ -263,8 +281,7 @@ candidate
     OCD Person indicating the candidate.
 
 designation
-    Enumerated among "supports", "opposes", "primary vehicle for", "surplus
-    account for", "independent expenditure" and other relationship types.
+    Enumerated among "primary vehicle for", "surplus account for", "independent expenditure" and other relationship types.
 
 Filing Type
 -----------

--- a/proposals/drafts/campaign_finance_filings.rst
+++ b/proposals/drafts/campaign_finance_filings.rst
@@ -16,7 +16,6 @@ Definitions
 -----------
 
 Campaign Finance Regulator (Regulator)
-
     Any government agency in charge of gathering information and enforcing
     transparency laws against political committees (Committees).
 

--- a/proposals/drafts/campaign_finance_filings.rst
+++ b/proposals/drafts/campaign_finance_filings.rst
@@ -30,8 +30,19 @@ Section
     A container for a unit of meaning inside a Filing, that isn't inherent to
     the basic process of filing a document with an agency.
 
+Ballot Measure
+    A proposition or question with two or more predetermined options that voters may select as part of an election. These include:
+
+    * The enactment or repeal of a statute, constitutional amendment or other form of law.
+    * Approval or rejection of a new tax or additional spending of public funds.
+    * The recall or retention of a previously elected public office holder.
+
+Candidacy
+    The condition of a person competing to hold a public office for defined term of office.
+
 Contest
-    A specific decision with a set of predetermined options put before voters via a ballot in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
+    A specific decision with a set of predetermined options put before voters in an election. These contests include the selection of a person from a list of candidates to hold a public office or the approval or rejection of a ballot measure.
+
 
 Rationale
 =========
@@ -232,20 +243,28 @@ statuses
         "contesting election" - allows for consolidating different
         jurisdictional status schemes into standard types.
 
-contest_positions
+candidacy_designations
     **optional**
     **repeated**
-    List of the election contests in which the committee has declared a preferred outcome. Has the following properties:
-
-    contest_id
-        Reference to the OCD ``Contest`` in which the committee has declared a position.
-
-    position
-        Enumerated among "supports" and "opposes".
+    List of the candidacies for which the committee has declared a position (e.g., support or oppose) or has otherwise focused its activity. Has the following properties:
 
     candidacy_id
-        **optional**
-        If the contest is a ``CandidateContest``, reference to a specific ``Candidacy`` the committee supports or opposes.
+        Reference to an OCD ``Candidacy``.
+    
+    designation
+        Enumerated among "supports", "opposes", "primary vehicle for", "surplus account for", "independent expenditure" and other relationship types.
+
+ballot_measure_options_supported
+    **optional**
+    **repeated**
+    List of the ballot measure contests in which the committee has declared support for a specific option. Has the following properties:
+
+    ballot_measure_contest_id
+        Reference to an OCD ``BallotMeasureContest``.
+
+    option
+        The specific ballot measure option supported by the committee, which are enumerated in ``BallotMeasureContest.options``.
+
 
 Committee Type
 --------------


### PR DESCRIPTION
Came about as a result of dialogue between @aepton, @fgregg and myself.

What's missing in the current campaign finance proposal is the ability to model relationships between campaign finance committees and the ballot measures they support or oppose. 

This is also related to the elections OCDEP we are discussing in PR #64.