### PR TITLE
[WIP] Reconcilliation Service

### DIFF
--- a/proposals/drafts/reconciliation.md
+++ b/proposals/drafts/reconciliation.md
@@ -1,0 +1,28 @@
+# Reconcilliation service:
+
+## Prior Art
+
+- https://web.archive.org/web/20161108220043/https://www.newschallenge.org/challenge/elections/entries/politician-reconciliation-service
+- https://web.archive.org/web/20130609195642/https://www.newschallenge.org/open/open-government/submission/civic-data-standardization-bootstrapper/
+- https://github.com/newsdev/nyt-entity-service
+- https://github.com/pudo/nomenklatura
+- google refine reconcilliation and freebase
+
+
+## Notes
+
+- match endpoint
+- add endpoint
+- bulk add endpoint
+- bulk access to data
+- copyright assignment to whom (shouldn't be datamade)
+
+
+## Key questions:
+1. What's the governance for accepting new entities
+2. What's the governance for merging and splitting existing entities
+3. If there is a merge or split how will changed entity ids propogate
+4. While DataMade can commit to supporting the service we are not going to make our full stack of dedupe.io open source
+is this a problem
+5. What type of entities are in scope--probably start with people.
+


### PR DESCRIPTION
This OCDEP proposes a design spec and governance model for an opencivicdata entity resolution service. This will allow publishers of civic data use the same ocd ids while staying loosely coupled.