### PR TITLE
Edits to Elections spec following implementation

### DIFF
--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -22,7 +22,6 @@ The proposed data types are:
     - ``RetentionContest``
 
 * ``Candidacy``
-* ``Party``
 
 Supplements the :doc:`Campaign Finance Filings <campaign_finance_filings>` proposal prepared by Abraham Epton, and lays the foundation for a future proposal covering election results.
 
@@ -416,7 +415,7 @@ posts
 
 party_id
     **optional**
-    If the contest is among candidates of the same political party, e.g., a partisan primary election, reference to the OCD ``Party`` representing that political party.
+    If the contest is among candidates of the same political party, e.g., a partisan primary election, reference to the OCD ``Organization`` representing that political party.
 
 previous_term_unexpired
     Indicates the previous public office holder vacated the post before serving a full term (boolean).
@@ -472,7 +471,7 @@ Mapping to VIP
 * Important differences between corresponding fields:
 
     - ``<OfficeIds>``, which is an optional set of references to VIP `<Office>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>`` should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
-    - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Party``.
+    - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Organization``.
     - ``<NumberElected>`` is an optional integer in VIP but is required in OCD, where it defaults to 1.
 
 * OCD fields not implemented in VIP:
@@ -492,10 +491,10 @@ A subclass of ``Contest`` for representing a contest in which voters can vote di
 
 parties
     **repeated**
-    List of references to each OCD ``Party`` for which a voter could vote in the election contest. Requires at list one. Has the following properties:
+    List of references to each party for which a voter could vote in the contest. Requires at list one. Has the following properties:
 
     party_id
-        Reference to an OCD ``Party``.
+        Reference to an OCD ``Organization``, with the `"party"` classification.
 
     is_incumbent
         **optional**
@@ -543,7 +542,7 @@ Mapping to VIP
 
 * OCD fields not implemented in VIP:
     
-    - ``parties`` should list the distinct party selections across all ballots that include the ``<PartyContest>`` (i.e., each OCD ``Party`` equivalent to each VIP ``<Party>`` referenced in the ``<PartyIds>`` tag in the `<PartySelection>`_ element).
+    - ``parties`` should list the distinct party selections across all ballots that include the ``<PartyContest>`` (i.e., each OCD ``Organization`` equivalent to each VIP ``<Party>`` referenced in the ``<PartyIds>`` tag in the `<PartySelection>`_ element).
     - ``runoff_for_contest_id`` an optional field.
 
 
@@ -645,7 +644,7 @@ is_incumbent
 
 party_id
     **optional**
-    Reference to an OCD ``Party`` with which the candidate is affiliated.
+    Reference to an OCD ``Organzation`` with which the candidate is affiliated.
 
 top_ticket_candidacy_id
     **optional**
@@ -703,7 +702,7 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
   
-    - ``<PartyId>``, which is an optional reference a VIP `<Party>`_ element, can map to an equivalent OCD ``Party``.
+    - ``<PartyId>``, which is an optional reference a VIP `<Party>`_ element, can map to an equivalent OCD ``Organization``.
     - ``person_id`` , which is an optional reference a VIP `<Person>`_ element, can map to an equivalent OCD ``Person``.
     - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates, is replaced by an optional ``top_ticket_candidacy_id``.
     - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus>`_ is replaced by an optional ``registration_status``.
@@ -717,80 +716,6 @@ Mapping to VIP
 
     - ``<ContactInformation>`` refers to an element that describes the contact and physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be stored on the associated ``Person`` or ``Committee`` object.
     - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus>`_.
-
-
-Party
------
-
-A political party with which office holders and candidates may be affiliated.
-
-``Party`` is a subclass of OCD's ``Organization`` data type, defined in :doc:`../0005`, which was accepted in June 2014. All of required and optional properties of ``Organization`` are inherited by ``Party``.
-
-abbreviation
-    **optional**
-    An abbreviation for the party name (string).
-
-color
-    **optional**
-    Six-character hex code representing an HTML color string. The pattern is ``[0-9a-f]{6}``.
-
-is_write_in
-    **optional**
-    Indicates that the party is not officially recognized by a local, state, or federal organization but, rather, is a "write-in" in jurisdictions which allow candidates to free-form enter their political affiliation (boolean).
-
-
-Sample Party
-++++++++++++
-
-
-.. code:: javascript
-
-    {
-        "id": "ocd-organization/866e7266-0c21-4476-a7a7-dc11d2ae8cd1"
-        "name": "DEMOCRATIC",
-        "image": "",
-        "parent": null,
-        "jurisdiction": null,
-        "classification": "party",
-        "founding_date": null,
-        "dissolution_date": null,
-        "identifiers": [],
-        "other_names": [],
-        "contact_details": [],
-        "links": [],
-        "abbreviation": "D",
-        "color": "1d0ee9",
-        "is_write_in": false,
-        "created_at": "2017-02-07T16:36:12.497Z",
-        "updated_at": "2017-02-07T16:36:12.497Z",
-        "sources": [],
-        "extras": {}
-    }
-
-
-Mapping to VIP
-++++++++++++++
-
-``Party`` corresponds to VIP's `<Party>`_ element.
-
-* Important differences between corresponding fields:
-
-    - ``<Name>`` is not required on VIP's ``<Party>``, but ``name`` (inherited from OCD's ``Organization``) is required.
-
-* OCD fields not implemented in VIP:
-
-    - ``classification`` (inherited from ``Organization``) should be "party".
-    - ``parent`` (inherited from ``Organization``) is optional.
-    - ``jurisdiction`` (inherited from ``Organization``) is optional.
-    - ``founding_date`` (inherited from ``Organization``) is optional.
-    - ``dissolution_date`` (inherited from ``Organization``) is optional.
-    - ``other_names`` (inherited from ``Organization``) is optional.
-    - ``contact_details`` (inherited from ``Organization``) is optional.
-    - ``links`` (inherited from ``Organization``) is optional.
-
-* VIP fields not implemented in this OCDEP:
-  
-    - ``<LogoUri>``, which is optional.
 
 
 Copyright

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -521,7 +521,7 @@ parties
     List of references to each party voters may choose in the contest. Requires at list one. Has the following properties:
 
     party_id
-        Reference to an OCD ``Organization``, with the "party" classification.
+        Reference to an OCD ``Organization`` representing a political party voters may choose in the contest.
 
     is_incumbent
         **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -150,10 +150,10 @@ administrative_organization_id
     Reference to the ``OCD`` Organization that administers the election.
 
 created_at
-    Time that this object was created at in the system.
+    Date and time when the object was created at in the system.
 
 updated_at
-    Time that this object was last updated in the system.
+    Date and time when the object was last updated in the system.
 
 sources
     **optional**
@@ -258,10 +258,10 @@ election_id
     Reference to the OCD ``Election`` in which the contest is decided.
 
 created_at
-    Time that this object was created at in the system.
+    Date and time when this object was created at in the system.
 
 updated_at
-    Time that this object was last updated in the system.
+    Date and time when object was last updated in the system.
 
 sources
     **optional**
@@ -680,10 +680,10 @@ top_ticket_candidacy_id
     If the candidate is running as part of ticket, e.g., a Vice Presidential candidate running with a Presidential candidate, reference to candidacy at the top of the ticket.
 
 created_at
-    Specifies when this object was created in the system (datetime).
+    Date and time when this object was created at in the system.
 
 updated_at
-    Specifies when this object was last updated in the system (datetime).
+    Date and time when this object was last updated in the system (datetime).
 
 sources
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -673,7 +673,7 @@ is_incumbent
 
 party_id
     **optional**
-    Reference to the political party (an OCD ``Organzation``) that nominated the candidate or would nominate the candidate (as in the case of a partisan primary).
+    Reference to an OCD ``Organzation`` representing the political party that nominated the candidate or would nominate the candidate (as in the case of a partisan primary).
 
 top_ticket_candidacy_id
     **optional**

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -149,7 +149,7 @@ division_id
 
 administrative_organization_id
     **optional**
-    Reference to the OCD ``Organization`` that administers the election and publishes the official results.
+    Reference to the ``OCD`` Organization that administers the election.
 
 sources
     **optional**
@@ -157,10 +157,10 @@ sources
     List of sources used in assembling this object. Has the following properties:
 
     url
-        URL of the resource.
+        A hyperlink related to an object.
     note
         **optional**
-        Description of what this source was used for.
+        A short, optional note related to an object.
 
 
 Sample Election
@@ -264,10 +264,10 @@ sources
     List of sources used in assembling this object. Has the following properties:
 
     url
-        URL of the resource.
+        A hyperlink related to an object.
     note
         **optional**
-        Description of what this source was used for.
+        A short, optional note related to an object
 
 extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
@@ -425,7 +425,7 @@ posts
     List of references to each OCD ``Post`` representing a public office for which the candidates in the contest are seeking election. Requires at least one. Has the following properties:
 
     post_id
-        Reference to an OCD ``OfficeTerm``.
+        Reference to the OCD ``Post`` at stake in the CandidateContest.
 
     sort_order
         **optional**
@@ -668,7 +668,7 @@ is_incumbent
 
 party_id
     **optional**
-    Reference to an OCD ``Organzation`` with which the candidate is affiliated.
+    Reference to the political party (an OCD ``Organzation``) that nominated the candidate or would nominate the candidate (as in the case of a partisan primary).
 
 top_ticket_candidacy_id
     **optional**
@@ -686,10 +686,10 @@ sources
     List of sources used in assembling this object. Has the following properties:
 
     url
-        URL of the resource.
+        A hyperlink related to an object.
     note
         **optional**
-        Description of what this source was used for.
+        A short, optional note related to an object.
 
 extras
     Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -13,7 +13,7 @@ Definition of data types to model elections, candidacies for public office and b
 
 The proposed data types are:
 
-* ``Election``
+* ``Election`` [#]_
 * ``Contest``, a base class for:
 
     - ``BallotMeasureContest``
@@ -68,7 +68,7 @@ Office Term
     For a variety of reasons, an office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
 
 Party
-    A political organization to which public office holders and candidates can be affiliated. In some electoral systems, such as `party-list proportional representation`_, voters may also directly elect political parties to hold power in lieu of or in addition to specific candidates endorsed by the political party.
+    A political organization to which public office holders and candidates can be affiliated. In some electoral systems, such as `party-list proportional representation`_, voters may also directly elect political parties to hold power in lieu of or in addition to voting for specific candidates endorsed by the political party.
 
 Public Office
     A position within a governmental body which is filled through an election contest.
@@ -122,9 +122,16 @@ Implementation
 Election
 --------
 
-A collection of political contests set to be decided on the same date within a political geography (aka, ``Division``).
+A collection of political contests set to be decided on the same date within a Division.    
 
-``Election`` is a subclass of OCD's ``Event`` data type, defined in :doc:`../0004`, which was accepted in June 2014. All of the required and optional properties of ``Event`` are inherited by ``Election``. The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
+id
+    Open Civic Data-style id, in the format ocd-election/{{uuid}}.
+
+name
+    Name of the election.
+
+date
+    Final or only date when eligible voters may cast their ballots in the Election. Typically this is also the same date when results of the election's contests are first publicly reported.
 
 identifiers
     **optional**
@@ -157,20 +164,15 @@ Sample Election
 .. code:: javascript
 
     {
-        "id": "ocd-event/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "id": "ocd-election/4c25d655-c380-46a4-93d7-28bc0c389629",
+        "name": "2016 GENERAL",
+        "date": "2016-11-08",
         "identifiers": [
             {
                 "scheme": "calaccess_election_id",
                 "identifier": "65"
             }
         ],
-        "name": "2016 GENERAL",
-        "description": "",
-        "start_time": "2016-11-08T00:00:00Z",
-        "end_time": null,
-        "timezone": "US/Pacific",     
-        "all_day": true,      
-        "classification": "election",
         "division_id": "ocd-division/country:us/state:ca/",
         "administrative_organization_id": "ocd-organization/436b4d67-b5aa-402c-9e20-0e56a8432c80",
         "created_at": "2017-02-07T07:17:58.874Z",
@@ -185,7 +187,7 @@ Sample Election
                 "url": "http://cal-access.ss.ca.gov/Campaign/Measures/list.aspx?session=2015"
             }
         ],
-        "extras": {},
+        "extras": {"calaccess_election_type": ["GENERAL"]},
     }
 
 
@@ -196,22 +198,12 @@ Mapping to VIP
 
 * Important differences between corresponding fields:
 
-    - ``<Name>`` is not required on VIP's ``<Election>``, but ``name`` (inherited from OCD's ``Event``) is required.
+    - ``<Name>`` is not required on VIP's ``<Election>`` but is required in OCD.
     - ``<StateId>``, which is a required reference to a VIP `<State>`_ element, should map to an equivalent OCD ``division_id`` if ``<IsStatewide>`` is ``true``. Otherwise, ``division_id`` should reference the appropriate subdivision of the equivalent to ``<StateId>``.
 
 * OCD fields not implemented in VIP:
 
     - ``administrative_organization_id`` is an optional reference to an OCD ``Organization`` that's equivalent to the ``<Department>`` tag in VIP's `<ElectionAdministration>`_ element.
-    - ``classification`` (inherited from ``Event``) should be "election".
-    - ``description`` (inherited from ``Event``) is optional.
-    - ``location`` (inherited from ``Event``) is optional.
-    - ``all_day`` (inherited from ``Event``) is optional.
-    - ``end_time`` (inherited from ``Event``) is optional.
-    - ``status`` (inherited from ``Event``) is optional.
-    - ``links`` (inherited from ``Event``) is optional.
-    - ``participants`` (inherited from ``Event``) is optional.
-    - ``documents`` (inherited from ``Event``) is optional.
-    - ``media`` (inherited from ``Event``) is optional.
 
 * VIP fields not implemented in this OCDEP:
 
@@ -806,6 +798,8 @@ Copyright
 
 This document has been placed in the public domain per the `Creative Commons CC0 1.0 Universal license <http://creativecommons.org/publicdomain/zero/1.0/deed>`_.
 
+
+.. [#] ``Election`` is conceptually similar to a couple of existing OCD data types: 1) ``Event`` which represents a hearing or opportunity for public testimony, as defined in :doc:`../0004`; and 2) ``VoteEvent`` which represents the event of a legislative vote taking place, as defined in :doc:`../0007`. A future OCDEP might define a base class with properties shared by all event-like data types, including a shared id format (e.g., ``ocd-event/{{uuid}}``).
 
 .. _California Civic Data Coalition: http://www.californiacivicdata.org/
 .. _party-list proportional representation: https://en.wikipedia.org/wiki/Party-list_proportional_representation

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -135,7 +135,14 @@ date
 identifiers
     **optional**
     **repeated**
-    Upstream identifiers of the election if any exist, such as those assigned by a Secretary of State, county or city elections office.
+    Upstream identifiers of the election, such as those assigned by a Secretary of State, county or city elections office.
+
+    Each element in identifiers is an object with the following keys:
+
+    scheme
+        The name of the service that created the identifier.
+    identifier
+        A unique identifier developed by an upstream or third party source.
 
 division_id
     Reference to the OCD ``Division`` that defines the broadest political geography of any contest to be decided by the election. For example, an election that includes a contest to elect the governor of California would include the division identifier for the entire state of California.
@@ -227,7 +234,14 @@ id
 identifiers
     **optional**
     **repeated**
-    Upstream identifiers of the contest if any exist, such as those assigned by a Secretary of State, county or city elections office.
+    Upstream identifiers of the contest, such as those assigned by a Secretary of State, county or city elections office.
+
+    Each element in identifiers is an object with the following keys:
+
+    scheme
+        The name of the service that created the identifier.
+    identifier
+        A unique identifier developed by an upstream or third party source.
 
 name
     Name of the contest, not necessarily as it appears on the ballot (string).

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -149,6 +149,12 @@ administrative_organization_id
     **optional**
     Reference to the ``OCD`` Organization that administers the election.
 
+created_at
+    Time that this object was created at in the system.
+
+updated_at
+    Time that this object was last updated in the system.
+
 sources
     **optional**
     **repeated**
@@ -159,6 +165,9 @@ sources
     note
         **optional**
         A short, optional note related to an object.
+
+extras
+    Common to all Open Civic Data types, the value is a key-value store suitable for storing arbitrary information not covered elsewhere.
 
 
 Sample Election

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -3,7 +3,7 @@ OCDEP: Elections
 ====================
 
 :Created: 2016-12-28
-:Author: James Gordon, Forest Gregg, `California Civic Data Coalition <http://www.californiacivicdata.org/>`_
+:Author: James Gordon, Forest Gregg, `California Civic Data Coalition`_
 :Status: Proposed
 
 Overview
@@ -24,7 +24,7 @@ The proposed data types are:
 * ``Candidacy``
 * ``Party``
 
-Supplements the "Campaign Finance Filings" proposal prepared by Abraham Epton, and lays the foundation for a future proposal covering election results.
+Supplements the :doc:`Campaign Finance Filings <campaign_finance_filings>` proposal prepared by Abraham Epton, and lays the foundation for a future proposal covering election results.
 
 Definitions
 ===========
@@ -68,7 +68,7 @@ Office Term
     For a variety of reasons, an office holder may vacate an elected office before serving a full term. This is known as an "unexpired term", a situation which could require an additional contest (known as a "Special Election" in U.S. politics) to fill the empty public office.
 
 Party
-    A political organization to which public office holders and candidates can be affiliated. In some electoral systems, such as `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_, voters may also directly elect political parties to hold power in lieu of or in addition to specific candidates endorsed by the political party.
+    A political organization to which public office holders and candidates can be affiliated. In some electoral systems, such as `party-list proportional representation`_, voters may also directly elect political parties to hold power in lieu of or in addition to specific candidates endorsed by the political party.
 
 Public Office
     A position within a governmental body which is filled through an election contest.
@@ -99,9 +99,9 @@ This proposal is submitted in response to on-going discussion around a related O
 
 The goal of this proposal is to cover the use cases related to the campaign finance domain while laying the foundation for models that will include election results (to be covered in a future OCDEP).
 
-Our use cases require unique representations of both previous elections and contests as well as pending elections and contests. While honoring these requirements, we also aim for consistency with the Voting Information Project's `XML format specification <http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements>`_ so as to support a high degree of interoperability with that existing data standard.
+Our use cases require unique representations of both previous elections and contests as well as pending elections and contests. While honoring these requirements, we also aim for consistency with the Voting Information Project's `XML format specification`_ so as to support a high degree of interoperability with that existing data standard.
 
-VIP 5, the specification's current version, incorporates elements from the `Election Results Common Data Format Specification <https://www.nist.gov/itl/voting/nist-election-results-common-data-format-specification>`_ defined by the National Institute of Standard and Technology. As such, we have borrowed eagerly from NIST's current specification also.
+VIP 5, the specification's current version, incorporates elements from the `Election Results Common Data Format Specification`_ defined by the National Institute of Standard and Technology. As such, we have borrowed eagerly from NIST's current specification also.
 
 Differences from VIP
 --------------------
@@ -114,7 +114,7 @@ The three major differences are:
 
 Important differences between the proposed OCD data type and its corresponding VIP element, if any, are noted in each data type's "Mapping to VIP" subsection in Implementation_.
 
-Additionally, VIP describes `<InternationalizedText> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html>`_ and `<LanguageString> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. These are treated as strings in this proposal.
+Additionally, VIP describes `<InternationalizedText>`_ and `<LanguageString>`_ elements for the purposes of representing certain texts in multiple languages, e.g., the English and Spanish translations of the ``support_statement`` and ``oppose_statement`` of a ``BallotMeasureContest``. These are treated as strings in this proposal.
 
 Implementation
 ==============
@@ -124,7 +124,7 @@ Election
 
 A collection of political contests set to be decided on the same date within a political geography (aka, ``Division``).
 
-``Election`` is a subclass of OCD's ``Event`` data type, defined in `OCDEP 4: Events <http://opencivicdata.readthedocs.io/en/latest/proposals/0004.html>`_, which was accepted in June 2014. All of the required and optional properties of ``Event`` are inherited by ``Election``. The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
+``Election`` is a subclass of OCD's ``Event`` data type, defined in :doc:`../0004`, which was accepted in June 2014. All of the required and optional properties of ``Event`` are inherited by ``Election``. The typical implementation will be an ``all_day`` event with an "election" ``classification`` value and a ``start_time`` set to midnight of the observed election date.
 
 identifiers
     **optional**
@@ -192,16 +192,16 @@ Sample Election
 Mapping to VIP
 ++++++++++++++
 
-``Election`` corresponds to VIP's `<Election> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html>`_ element.
+``Election`` corresponds to VIP's `<Election>`_ element.
 
 * Important differences between corresponding fields:
 
     - ``<Name>`` is not required on VIP's ``<Election>``, but ``name`` (inherited from OCD's ``Event``) is required.
-    - ``<StateId>``, which is a required reference to a VIP `<State> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html>`_ element, should map to an equivalent OCD ``division_id`` if ``<IsStatewide>`` is ``true``. Otherwise, ``division_id`` should reference the appropriate subdivision of the equivalent to ``<StateId>``.
+    - ``<StateId>``, which is a required reference to a VIP `<State>`_ element, should map to an equivalent OCD ``division_id`` if ``<IsStatewide>`` is ``true``. Otherwise, ``division_id`` should reference the appropriate subdivision of the equivalent to ``<StateId>``.
 
 * OCD fields not implemented in VIP:
 
-    - ``administrative_organization_id`` is an optional reference to an OCD ``Organization`` that can be equivalent to the ``<Department>`` tag in VIP's `<ElectionAdministration> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election_administration.html>`_   element.
+    - ``administrative_organization_id`` is an optional reference to an OCD ``Organization`` that's equivalent to the ``<Department>`` tag in VIP's `<ElectionAdministration>`_ element.
     - ``classification`` (inherited from ``Event``) should be "election".
     - ``description`` (inherited from ``Event``) is optional.
     - ``location`` (inherited from ``Event``) is optional.
@@ -216,7 +216,7 @@ Mapping to VIP
 * VIP fields not implemented in this OCDEP:
 
     - ``<ElectionType>``, which is optional for describing either the level of government to which a candidate might be elected (e.g., "federal", "state", "county", etc.) or the point when the election occurs in the overall cycle (e.g., "general", "primary", "runoff" and "special").
-    - ``<HoursOpenId>``, which is an optional reference to a VIP `<HoursOpen> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/hours_open.html>`_ element that represents when polling locations for the election are generally open.
+    - ``<HoursOpenId>``, which is an optional reference to a VIP `<HoursOpen>`_ element that represents when polling locations for the election are generally open.
     - ``<RegistrationInfo>``, which optional text.
     - ``<RegistrationDeadline>``, which is an optional date.
     - ``<HasElectionDayRegistration>``, which is an optional boolean.
@@ -295,11 +295,11 @@ Sample Contest
 Mapping to VIP
 ++++++++++++++
 
-``Contest`` corresponds to VIP's `<ContestBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/contest_base.html>`_ element.
+``Contest`` corresponds to VIP's `<ContestBase>`_ element.
 
 * Important differences between corresponding fields:
 
-    - ``<ElectoralDistrictId>``, which is an optional reference to a VIP `<ElectoralDistrict> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html>`_ element, can map to an equivalent OCD ``division_id``.
+    - ``<ElectoralDistrictId>``, which is an optional reference to a VIP `<ElectoralDistrict>`_ element, can map to an equivalent OCD ``division_id``.
 
 * OCD fields not implemented in VIP:
 
@@ -308,13 +308,13 @@ Mapping to VIP
 * VIP fields not implemented in this OCDEP:
 
     - ``<Abbreviation>``, which is optional text.
-    - ``<BallotSelectionIds>`` is an optional single element that contains a set of references to each selection (i.e., any extension of VIP's `<BallotSelectionBase> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html>`_) on any ballot that includes the contest. This proposal instead represents the distinct options for each contest across all versions of the ballot.
+    - ``<BallotSelectionIds>`` is an optional single element that contains a set of references to each selection (i.e., any extension of VIP's `<BallotSelectionBase>`_) on any ballot that includes the contest. This proposal instead represents the distinct options for each contest across all versions of the ballot.
     - ``<ElectorateSpecification>``, which optional text.
     - ``<HasRotation>``, which is an optional boolean.
     - ``<BallotSubTitle>``,  which is optional text.
     - ``<BallotTitle>``,  which is optional text.
     - ``<SequenceOrder>``,  which is an optional integer.
-    - ``<VoteVariation>``,  which is an optional reference to a VIP `<VoteVariation> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/vote_variation.html>`_.
+    - ``<VoteVariation>``,  which is an optional reference to a VIP `<VoteVariation>`_.
     - ``<OtherVoteVariation>``, which is optional text.
 
 
@@ -384,16 +384,16 @@ Sample BallotMeasureContest
 Mapping to VIP
 ++++++++++++++
 
-``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html>`_ element.
+``BallotMeasureContest`` corresponds to VIP's `<BallotMeasureContest>`_ element.
 
 * Important differences between corresponding fields:
 
     - ``<PassageThreshold>`` maps to ``requirement``.
-    - ``<Type>``, which is an optional reference to a VIP `<BallotMeasureType> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/ballot_measure_type.html#multi-xml-ballot-measure-type>`_ maps to ``classification`` which is a simple string.
+    - ``<Type>``, which is an optional reference to a VIP `<BallotMeasureType>`_ maps to ``classification`` which is a simple string.
 
 * OCD fields not implemented in VIP:
 
-    - ``options`` should list the distinct selections across all ballots that include the ballot measure (i.e., the distinct ``<Selection>`` tags in the `<BallotMeasureSelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+    - ``options`` should list the distinct selections across all ballots that include the ballot measure (i.e., the distinct ``<Selection>`` tags in the `<BallotMeasureSelection>`_ element).
 
 * VIP fields not implemented in this OCDEP:
 
@@ -475,17 +475,17 @@ Sample CandidateContest
 Mapping to VIP
 ++++++++++++++
 
-``CandidateContest`` corresponds to VIP's `<CandidateContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_contest.html>`_ element.
+``CandidateContest`` corresponds to VIP's `<CandidateContest>`_ element.
 
 * Important differences between corresponding fields:
 
-    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>`` should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
-    - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Party``.
-    - ``<NumberElected>`` is an optional integer in VIP but not in OCD, where it defaults to 1.
+    - ``<OfficeIds>``, which is an optional set of references to VIP `<Office>`_ elements, correpsonds to ``posts``. Each ``<OfficeId>`` should map to an equivalent OCD ``Post`` and the order in which the ``<OfficeIds>`` are listed should be preserved in ``sort_order``.
+    - ``<PrimaryPartyIds>`` is an optional set of references to each `<Party>`_ related to the contest. This proposal allows for a ``CandidateContest`` to be linked to a single equivalent OCD ``Party``.
+    - ``<NumberElected>`` is an optional integer in VIP but is required in OCD, where it defaults to 1.
 
 * OCD fields not implemented in VIP:
 
-    + ``previous_term_unexpired`` should be ``true`` if the ``<OfficeTermType>`` referenced by the ``<Term>`` tag in VIP's `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element is "unexpired-term". Otherwise, ``previous_term_unexpired`` should be ``false``.
+    + ``previous_term_unexpired`` should be ``true`` if the ``<OfficeTermType>`` referenced by the ``<Term>`` tag in VIP's `<Office>`_ element is "unexpired-term". Otherwise, ``previous_term_unexpired`` should be ``false``.
     + ``runoff_for_contest_id`` is optional.
 
 * VIP fields not implemented in this OCDEP:
@@ -496,7 +496,7 @@ Mapping to VIP
 PartyContest
 ------------
 
-A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of/in addition voting for to candidates endorsed by that party (as in the case of `party-list proportional representation <https://en.wikipedia.org/wiki/Party-list_proportional_representation>`_ ). Inherits all the required and optional properties of ``Contest``.
+A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of/in addition voting for to candidates endorsed by that party (as in the case of `party-list proportional representation`_). Inherits all the required and optional properties of ``Contest``.
 
 parties
     **repeated**
@@ -547,11 +547,11 @@ Sample PartyContest
 Mapping to VIP
 ++++++++++++++
 
-``PartyContest`` corresponds to VIP's `<PartyContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html>`_ element. 
+``PartyContest`` corresponds to VIP's `<PartyContest>`_ element. 
 
 * OCD fields not implemented in VIP:
     
-    - ``parties`` should list the distinct party selections across all ballots that include the ``<PartyContest>`` (i.e., each OCD ``Party`` equivalent to each VIP ``<Party>`` referenced in the ``<PartyIds>`` tag in the `<PartySelection> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html>`_ element).
+    - ``parties`` should list the distinct party selections across all ballots that include the ``<PartyContest>`` (i.e., each OCD ``Party`` equivalent to each VIP ``<Party>`` referenced in the ``<PartyIds>`` tag in the `<PartySelection>`_ element).
     - ``runoff_for_contest_id`` an optional field.
 
 
@@ -607,11 +607,11 @@ Sample RetentionContest
 Mapping to VIP
 ++++++++++++++
 
-``RetentionContest`` corresponds to VIP's `<RetentionContest> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/retention_contest.html>`_ element.
+``RetentionContest`` corresponds to VIP's `<RetentionContest>`_ element.
 
 * Important differences between corresponding fields:
 
-    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element, and ``<OfficeId>``, which is an optional reference to a VIP `<Office> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html>`_ element, should map to an equivalent OCD ``Membership`` representing a specific person's (i.e, an OCD ``Person`` object) tenure in a specific public office (i.e., an OCD ``Post`` object).
+    - ``<CandidateId>``, which is a required reference to a VIP `<Candidate>`_ element, and ``<OfficeId>``, which is an optional reference to a VIP `<Office>`_ element, should map to an equivalent OCD ``Membership`` representing a specific person's (i.e, an OCD ``Person`` object) tenure in a specific public office (i.e., an OCD ``Post`` object).
 
 Candidacy
 ---------
@@ -707,14 +707,14 @@ Sample Candidacy
 Mapping to VIP
 ++++++++++++++
 
-``Candidacy`` corresponds to VIP's `<Candidate> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html>`_ element.
+``Candidacy`` corresponds to VIP's `<Candidate>`_ element.
 
 * Important differences between corresponding fields:
   
-    - ``<PartyId>``, which is an optional reference a VIP `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element, can map to an equivalent OCD ``Party``.
-    - ``person_id`` , which is an optional reference a VIP `<Person> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html>`_ element, can map to an equivalent OCD ``Person``.
+    - ``<PartyId>``, which is an optional reference a VIP `<Party>`_ element, can map to an equivalent OCD ``Party``.
+    - ``person_id`` , which is an optional reference a VIP `<Person>`_ element, can map to an equivalent OCD ``Person``.
     - ``<IsTopTicket>``, which is an optional boolean indicating the candidate is the top of a ticket that includes multiple candidates, is replaced by an optional ``top_ticket_candidacy_id``.
-    - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html>`_ is replaced by an optional ``registration_status``.
+    - ``<PreElectionStatus>``, which is an optional reference to a VIP `<CandidatePreElectionStatus>`_ is replaced by an optional ``registration_status``.
 
 * OCD fields not implemented in VIP:
       
@@ -724,7 +724,7 @@ Mapping to VIP
 * VIP fields not implemented in this OCDEP:
 
     - ``<ContactInformation>`` refers to an element that describes the contact and physical address information for the candidate or their campaign. On and OCD ``Candidacy``, this information would be stored on the associated ``Person`` or ``Committee`` object.
-    - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html>`_.
+    - ``<PostElectionStatus>``, which is an optional reference to a VIP `<CandidatePostElectionStatus>`_.
 
 
 Party
@@ -732,7 +732,7 @@ Party
 
 A political party with which office holders and candidates may be affiliated.
 
-``Party`` is a subclass of OCD's ``Organization`` data type, defined in `OCDEP 5: People, Organizations, Posts, and Memberships <http://opencivicdata.readthedocs.io/en/latest/proposals/0005.html>`_, which was accepted in June 2014. All of required and optional properties of ``Organization`` are inherited by ``Party``.
+``Party`` is a subclass of OCD's ``Organization`` data type, defined in :doc:`../0005`, which was accepted in June 2014. All of required and optional properties of ``Organization`` are inherited by ``Party``.
 
 abbreviation
     **optional**
@@ -779,7 +779,7 @@ Sample Party
 Mapping to VIP
 ++++++++++++++
 
-``Party`` corresponds to VIP's `<Party> <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html>`_ element.
+``Party`` corresponds to VIP's `<Party>`_ element.
 
 * Important differences between corresponding fields:
 
@@ -805,3 +805,32 @@ Copyright
 =========
 
 This document has been placed in the public domain per the `Creative Commons CC0 1.0 Universal license <http://creativecommons.org/publicdomain/zero/1.0/deed>`_.
+
+
+.. _California Civic Data Coalition: http://www.californiacivicdata.org/
+.. _party-list proportional representation: https://en.wikipedia.org/wiki/Party-list_proportional_representation
+.. _XML format specification: http://vip-specification.readthedocs.io/en/vip5/xml/index.html#elements
+.. _Election Results Common Data Format Specification: https://www.nist.gov/itl/voting/nist-election-results-common-data-format-specification
+.. _<InternationalizedText>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html
+.. _<LanguageString>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/internationalized_text.html#languagestring
+.. _<Election>: <http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election.html
+.. _<State>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/state.html
+.. _<ElectionAdministration>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/election_administration.html
+.. _<HoursOpen>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/hours_open.html 
+.. _<ContestBase>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/contest_base.html
+.. _<ElectoralDistrict>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/electoral_district.html
+.. _<BallotSelectionBase>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_selection_base.html
+.. _<VoteVariation>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/vote_variation.html
+.. _<BallotMeasureContest>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_contest.html
+.. _<BallotMeasureType>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/ballot_measure_type.html#multi-xml-ballot-measure-type
+.. _<BallotMeasureSelection>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html
+.. _<CandidateContest>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate_contest.html
+.. _<Office>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/office.html
+.. _<Party>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party.html
+.. _<PartyContest>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/party_contest.html
+.. _<PartySelection>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/ballot_measure_selection.html
+.. _<RetentionContest>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/retention_contest.html
+.. _<Candidate>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/candidate.html
+.. _<CandidatePreElectionStatus>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_pre_election_status.html
+.. _<CandidatePostElectionStatus>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/enumerations/candidate_post_election_status.html
+.. _<Person>: http://vip-specification.readthedocs.io/en/release/built_rst/xml/elements/person.html

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -326,7 +326,9 @@ Mapping to VIP
 BallotMeasureContest
 --------------------
 
-A subclass of ``Contest`` for representing a ballot measure before the voters, including options voters may select. Inherits all the required and optional properties of ``Contest``.
+A contest in which voters select from among options proposed in a ballot measure.
+
+``BallotMeasureContest`` inherits all the required and optional properties of ``Contest``.
 
 options
     **repeated**
@@ -414,7 +416,9 @@ Mapping to VIP
 CandidateContest
 ----------------
 
-A subclass of ``Contest`` for repesenting a contest among candidates seeking election to one or more public offices. Inherits all the required and optional properties of ``Contest``.
+A contest among candidates seeking election to one or more public offices. 
+
+``CandidateContest`` inherits all the required and optional properties of ``Contest``.
 
 posts
     **repeated**
@@ -501,7 +505,11 @@ Mapping to VIP
 PartyContest
 ------------
 
-A subclass of ``Contest`` for representing a contest in which voters can vote directly for a political party in lieu of/in addition voting for to candidates endorsed by that party (as in the case of `party-list proportional representation`_). Inherits all the required and optional properties of ``Contest``.
+A contest in which voters can vote directly for a political party.
+
+In these contests, voters can vote for a party in lieu of/in addition to voting for candidates endorsed by that party (as in the case of `party-list proportional representation`_). 
+
+``PartyContest`` inherits all the required and optional properties of ``Contest``.
 
 parties
     **repeated**
@@ -563,9 +571,11 @@ Mapping to VIP
 RetentionContest
 ----------------
 
-A subclass of ``BallotMeasureContest`` that represents a contest where voters vote to retain or recall a current office holder, e.g. a judicial retention or recall election. Inherits all the required and optional properties of ``BallotMeasureContest``.
+A contest where voters vote to retain or recall a current office holder.
 
-In a ``RetentionContest``, voters typically have two options (e.g., "yes" or "no", "recall" or "don't recall"), unlike in a ``CandidateContest`` where voters can choose from among multiple different candidates.
+These contests include judicial retention or recall elections.
+
+``RetentionContest`` inherits all the required and optional properties of ``BallotMeasureContest``.
 
 membership_id
     Reference to the OCD ``Membership`` that represents the tenure of a specific person (i.e., OCD ``Person`` object) in a specific public office (i.e., ``Post`` object).

--- a/proposals/drafts/elections.rst
+++ b/proposals/drafts/elections.rst
@@ -121,7 +121,7 @@ Implementation
 Election
 --------
 
-A collection of political contests set to be decided on the same date within a Division.    
+A collection of political contests set to be decided on the same date within a ``Division``.
 
 id
     Open Civic Data-style id, in the format ocd-election/{{uuid}}.
@@ -135,9 +135,7 @@ date
 identifiers
     **optional**
     **repeated**
-    Upstream identifiers of the election, such as those assigned by a Secretary of State, county or city elections office.
-
-    Each element in identifiers is an object with the following keys:
+    Upstream identifiers of the election, such as those assigned by a Secretary of State, county or city elections office. Has the following properties:
 
     scheme
         The name of the service that created the identifier.
@@ -234,9 +232,7 @@ id
 identifiers
     **optional**
     **repeated**
-    Upstream identifiers of the contest, such as those assigned by a Secretary of State, county or city elections office.
-
-    Each element in identifiers is an object with the following keys:
+    Upstream identifiers of the contest, such as those assigned by a Secretary of State, county or city elections office. Has the following properties:
 
     scheme
         The name of the service that created the identifier.
@@ -416,7 +412,7 @@ Mapping to VIP
 CandidateContest
 ----------------
 
-A contest among candidates seeking election to one or more public offices. 
+A contest among candidates seeking election to one or more public offices.
 
 ``CandidateContest`` inherits all the required and optional properties of ``Contest``.
 
@@ -507,16 +503,16 @@ PartyContest
 
 A contest in which voters can vote directly for a political party.
 
-In these contests, voters can vote for a party in lieu of/in addition to voting for candidates endorsed by that party (as in the case of `party-list proportional representation`_). 
+In these contests, voters can vote for a party in lieu of/in addition to voting for candidates endorsed by that party (as in the case of `party-list proportional representation`_).
 
 ``PartyContest`` inherits all the required and optional properties of ``Contest``.
 
 parties
     **repeated**
-    List of references to each party for which a voter could vote in the contest. Requires at list one. Has the following properties:
+    List of references to each party voters may choose in the contest. Requires at list one. Has the following properties:
 
     party_id
-        Reference to an OCD ``Organization``, with the `"party"` classification.
+        Reference to an OCD ``Organization``, with the "party" classification.
 
     is_incumbent
         **optional**
@@ -631,7 +627,7 @@ Mapping to VIP
 Candidacy
 ---------
 
-A person competing in an election contest to hold a specific office for a term.
+A person seeking election to hold a specific public office for a term.
 
 id
     Open Civic Data-style id in the format ``ocd-candidacy/{{uuid}}``.


### PR DESCRIPTION
We're submitting a few edits to the draft elections OCDEP arising from concerns that came up while implementing this specification in [python-opencivicdata](https://github.com/opencivicdata/python-opencivicdata).

Most significant changes to note:
1. Election no longer subclasses Event, but with the understanding that a future OCDEP might propose a base Event class with properties shared by Election, Event and VoteEvent.
2. Party is removed as a proposed data type, having no significant properties to distinguish it from Organization.

I've also just tidied up a few things (e.g., moved links to resources to the bottom of the .rst doc, corrected a few typos, etc.)

@jpmckinney @jamesturk @fgregg let us know if there are any questions/concerns.