### PR TITLE
Fix sphinx requirements so that site can be hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This repository contains documentation for developers including:
 * Open Civic Data's Data Type Specifications
 * Open Civic Data Proposals
 
-Read these docs at http://docs.opencivicdata.org/
+Read these docs at https://open-civic-data.readthedocs.io/en/latest/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2==2.11.3
-MarkupSafe>=0.19
+Jinja2>=3.1
+MarkupSafe>=2.0.1
 Pygments==2.7.4
 Sphinx>=1.2.2
 argparse==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-Jinja2==2.7.2
-MarkupSafe==0.19
-Pygments==1.6
-Sphinx>=1.2.2
-argparse==1.2.1
-docutils==0.11
-sphinx-rtd-theme==0.1.5
+Inirama>=0.7.0
+Jinja2>=2.6
+oset>=0.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.11.3
 MarkupSafe>=0.19
 Pygments==2.7.4
-Sphinx==1.2.2
+Sphinx>=1.2.2
 argparse==1.2.1
 docutils==0.11
 sphinx-rtd-theme==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Jinja2>=3.1
-MarkupSafe>=2.0.1
-Pygments==2.7.4
-Sphinx>=1.2.2
+Jinja2==2.7.2
+MarkupSafe==0.19
+Pygments==1.6
+Sphinx==1.2.2
 argparse==1.2.1
 docutils==0.11
 sphinx-rtd-theme==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.7.2
 MarkupSafe==0.19
 Pygments==1.6
-Sphinx==1.2.2
+Sphinx>=1.2.2
 argparse==1.2.1
 docutils==0.11
 sphinx-rtd-theme==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2==2.11.3
-MarkupSafe==0.19
+MarkupSafe>=0.19
 Pygments==2.7.4
 Sphinx==1.2.2
 argparse==1.2.1


### PR DESCRIPTION
Currently the requirements.txt cause the site not to build on Read The Docs (I think due to the fact that readthedocs is now using python3) https://readthedocs.org/projects/open-civic-data/.

Removing some of the dependencies that are causing the build to fail.