### PR TITLE
Point Popolo links at https://www.popoloproject.com

### DIFF
--- a/data/datatypes.rst
+++ b/data/datatypes.rst
@@ -22,7 +22,7 @@ The Open Civic Data specifications define the following core types:
 **person**
     A person, typically a politician or government official.
 
-    The `Popolo person schema <http://popoloproject.com/specs/person.html>`_ is used to represent
+    The `Popolo person schema <https://www.popoloproject.com/specs/person.html>`_ is used to represent
     person data.
 
     See :doc:`person` for details.
@@ -30,7 +30,7 @@ The Open Civic Data specifications define the following core types:
 **organization**
     A group of people, such as a city council, state senate, or committee.
 
-    The `Popolo organization schema <http://popoloproject.com/specs/organization.html>`_ is used to
+    The `Popolo organization schema <https://www.popoloproject.com/specs/organization.html>`_ is used to
     represent organization data.
 
     See :doc:`organization` for details.

--- a/proposals/0005.rst
+++ b/proposals/0005.rst
@@ -9,7 +9,7 @@ OCDEP 5: People, Organizations, Posts, and Memberships
 Overview
 ========
 
-Adoption of `Popolo <http://popoloproject.com/>`_ types for the Open Civic Data Person, Organization, Post, and Membership types.
+Adoption of `Popolo <https://www.popoloproject.com/>`_ types for the Open Civic Data Person, Organization, Post, and Membership types.
 
 Definitions
 -----------
@@ -42,7 +42,7 @@ To avoid duplicating the entire Popolo specification, this proposal only aims to
 Person
 ------
 
-The basis for the Open Civic Data ``Person`` object is the `Popolo Person <http://popoloproject.com/specs/person.html>`_.
+The basis for the Open Civic Data ``Person`` object is the `Popolo Person <https://www.popoloproject.com/specs/person.html>`_.
 
 Omitted Fields
 ~~~~~~~~~~~~~~
@@ -65,7 +65,7 @@ extras
 Organization
 ------------
 
-The basis for the Open Civic Data ``Organization`` object is the `Popolo Organization <http://popoloproject.com/specs/organization.html>`_.
+The basis for the Open Civic Data ``Organization`` object is the `Popolo Organization <https://www.popoloproject.com/specs/organization.html>`_.
 
 Omitted Fields
 ~~~~~~~~~~~~~~
@@ -87,7 +87,7 @@ extras
 Post
 ----
 
-The basis for the Open Civic Data ``Post`` object is the `Popolo Post <http://popoloproject.com/specs/post.html>`_.
+The basis for the Open Civic Data ``Post`` object is the `Popolo Post <https://www.popoloproject.com/specs/post.html>`_.
 
 
 Omitted Fields
@@ -113,7 +113,7 @@ extras
 Membership
 ----------
 
-The basis for the Open Civic Data ``Membership`` object is the `Popolo Membership <http://popoloproject.com/specs/membership.html>`_.
+The basis for the Open Civic Data ``Membership`` object is the `Popolo Membership <https://www.popoloproject.com/specs/membership.html>`_.
 
 
 Omitted Fields

--- a/proposals/0007.rst
+++ b/proposals/0007.rst
@@ -13,7 +13,7 @@ Overview
 
 Definition of the Open Civic Data vote types.
 
-(Based in part on `Popolo <http://popoloproject.com/>`_ types for the Open Civic Data Vote and VoteEvent).
+(Based in part on `Popolo <https://www.popoloproject.com/>`_ types for the Open Civic Data Vote and VoteEvent).
 
 
 Rationale
@@ -24,7 +24,7 @@ legislative accountability.  The ``VoteEvent`` type and its related subtypes exi
 of votes (meaning the outcome of a proposal as well as the individual positions of legislators).
 
 An attempt has been made to reconcile our vote types (originally based in Open States work)
-with the schemas put forward by the `Popolo specification <http://popoloproject.com/specs/vote-event.html>`_.
+with the schemas put forward by the `Popolo specification <https://www.popoloproject.com/specs/vote-event.html>`_.
 
 
 Implementation
@@ -57,7 +57,7 @@ motion
 
     ``classification`` is a list of classifiers (e.g. 'bill-passage') and can also be an empty list.
 
-    In Popolo there is a `Motion <http://popoloproject.com/specs/motion.html>`_ class that has additional properties, only text and classification are supported at this time.
+    In Popolo there is a `Motion <https://www.popoloproject.com/specs/motion.html>`_ class that has additional properties, only text and classification are supported at this time.
 
 
 start_date
@@ -82,7 +82,7 @@ bill, bill_id
 
 votes
     A list of objects representing individual legislator's votes.  (Popolo refers to these as
-    `Vote <http://popoloproject.com/specs/vote.html>`_).
+    `Vote <https://www.popoloproject.com/specs/vote.html>`_).
 
     This list may not be present if the individual voters are not known, for example in the case of a
     voice vote.
@@ -105,7 +105,7 @@ votes
         might be an excuse if the option is 'excused'.
 
 counts
-    A list of count objects (what Popolo calls `Count <http://popoloproject.com/specs/count.html>`_).
+    A list of count objects (what Popolo calls `Count <https://www.popoloproject.com/specs/count.html>`_).
 
     These represent the total number of individuals voting a particular way.  Each has two properties:
 

--- a/scrape/people.rst
+++ b/scrape/people.rst
@@ -191,7 +191,7 @@ Special notes regarding Posts, Memberships and Districts
 
 The keen observer will note that we're using role, district and primary_org to note the person's primary position.
 
-Looking at the `Popolo spec <http://popoloproject.com/>`_, you might be
+Looking at the `Popolo spec <https://www.popoloproject.com/>`_, you might be
 confused on why this isn't an opaque ID, or some sort of slug.
 
 We use full strings to help avoid having to search through all available organizations at scrape-time. The resolution is done at import-time.


### PR DESCRIPTION
Closes #116. The 13 Popolo references in the docs all used the bare `http://popoloproject.com` host, which stopped resolving at some point. The site is alive at `www.popoloproject.com` over HTTPS, so this just adds the subdomain and bumps the scheme.